### PR TITLE
✨ [Feature] 쪽지 전송 API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { CommonModule } from '@common/common.module';
 import { validateEnv } from '@configs/process-env.config';
 import { AuthModule } from '@modules/auth/auth.module';
 import { HealthModule } from '@modules/health/health.module';
+import { MessagesModule } from '@modules/messages/messages.module';
 import { QuestionsModule } from '@modules/questions/questions.module';
 import { UsersModule } from '@modules/users/users.module';
 
@@ -27,6 +28,7 @@ import { LoggerModule } from './logger/logger.module';
     AuthModule,
     UsersModule,
     QuestionsModule,
+    MessagesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/decorators/is-bigint-id-string.decorator.ts
+++ b/src/common/decorators/is-bigint-id-string.decorator.ts
@@ -1,0 +1,37 @@
+import {
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  registerDecorator,
+} from 'class-validator';
+
+import { validateBigIntIdString } from '@common/validators/bigint-string.validator';
+
+@ValidatorConstraint({ name: 'isBigIntIdString', async: false })
+export class IsBigIntIdStringConstraint implements ValidatorConstraintInterface {
+  validate(value: string) {
+    return validateBigIntIdString(value);
+  }
+
+  defaultMessage() {
+    return 'Value must be a valid BigInt string';
+  }
+}
+
+/**
+ * class validator에서 사용할 BigInt string 유효성 검사 데코레이터
+ *
+ * @param validationOptions
+ * @returns
+ */
+export function IsBigIntIdString(validationOptions?: ValidationOptions) {
+  return (object: unknown, propertyName: string) => {
+    registerDecorator({
+      name: 'isBigIntIdString',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: IsBigIntIdStringConstraint,
+    });
+  };
+}

--- a/src/common/pipes/check-bigint-id.pipe.ts
+++ b/src/common/pipes/check-bigint-id.pipe.ts
@@ -1,8 +1,5 @@
+import { validateBigIntIdString } from '@common/validators/bigint-string.validator';
 import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
-import { isNumberString } from 'class-validator';
-
-const MAX_BIGINT = '9223372036854775807';
-const MAX_BIGINT_LENGTH = 19;
 
 /**
  * 숫자 형식이 아니면 error
@@ -15,35 +12,10 @@ const MAX_BIGINT_LENGTH = 19;
 @Injectable()
 export class CheckBigIntIdPipe implements PipeTransform {
   transform(value: string) {
-    if (this.isBigIntString(value) === false) {
-      throw new BadRequestException('Invalid id format');
+    if (validateBigIntIdString(value) === false) {
+      throw new BadRequestException('Invalid bigint id');
     }
 
     return value;
-  }
-
-  private isBigIntString(value: string): boolean {
-    return (
-      this.isNumericString(value) &&
-      !this.hasLeadingZero(value) &&
-      !this.exceedsMaxLength(value) &&
-      !this.exceedsMaxValue(value)
-    );
-  }
-
-  private isNumericString(value: string): boolean {
-    return isNumberString(value, { no_symbols: true }); // 숫자 문자열 확인
-  }
-
-  private hasLeadingZero(value: string): boolean {
-    return value.startsWith('0'); // 선행 0 확인
-  }
-
-  private exceedsMaxLength(value: string): boolean {
-    return value.length > MAX_BIGINT_LENGTH; // 길이 초과 확인
-  }
-
-  private exceedsMaxValue(value: string): boolean {
-    return value > MAX_BIGINT; // 최대값 초과 확인
   }
 }

--- a/src/common/validators/bigint-string.validator.ts
+++ b/src/common/validators/bigint-string.validator.ts
@@ -1,0 +1,24 @@
+import { isNumberString } from 'class-validator';
+
+const MAX_BIGINT = '9223372036854775807';
+const MAX_BIGINT_LENGTH = 19;
+
+export const validateBigIntIdString = (value: string): boolean => {
+  return isNumericString(value) && !hasLeadingZero(value) && !exceedsMaxLength(value) && !exceedsMaxValue(value);
+};
+
+const isNumericString = (value: string): boolean => {
+  return isNumberString(value, { no_symbols: true }); // 숫자 문자열 확인
+};
+
+const hasLeadingZero = (value: string): boolean => {
+  return value.startsWith('0'); // 선행 0 확인
+};
+
+const exceedsMaxLength = (value: string): boolean => {
+  return value.length > MAX_BIGINT_LENGTH; // 길이 초과 확인
+};
+
+const exceedsMaxValue = (value: string): boolean => {
+  return value > MAX_BIGINT; // 최대값 초과 확인
+};

--- a/src/entities/message.entity.ts
+++ b/src/entities/message.entity.ts
@@ -1,3 +1,4 @@
+import { MESSAGE_CONTENT_MAX } from '@modules/messages/constants/messages.constant';
 import {
   Column,
   CreateDateColumn,
@@ -26,7 +27,7 @@ export class Message {
   @PrimaryGeneratedColumn({ type: 'bigint', name: 'message_id' })
   messageId: string;
 
-  @Column({ length: 200 })
+  @Column({ length: MESSAGE_CONTENT_MAX })
   content: string;
 
   @Column({ type: 'smallint', default: MessageStatus.NORMAL })

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -10,7 +10,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(
-    configService: ConfigService,
+    private readonly configService: ConfigService,
     private readonly usersService: UsersService,
   ) {
     super({

--- a/src/modules/messages/constants/messages.constant.ts
+++ b/src/modules/messages/constants/messages.constant.ts
@@ -1,0 +1,2 @@
+export const MESSAGE_CONTENT_MAX = 200;
+export const MESSAGE_CONTENT_MIN = 2;

--- a/src/modules/messages/dto/create-message.dto.ts
+++ b/src/modules/messages/dto/create-message.dto.ts
@@ -1,0 +1,49 @@
+import { IsBigIntIdString } from '@common/decorators/is-bigint-id-string.decorator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, Length } from 'class-validator';
+import { MESSAGE_CONTENT_MAX, MESSAGE_CONTENT_MIN } from '../constants/messages.constant';
+
+export class CreateMessageDto {
+  @ApiProperty({
+    description: '쪽지를 받을 유저의 id',
+    example: '1',
+    required: true,
+  })
+  @IsBigIntIdString()
+  receiverId: string;
+
+  @ApiProperty({
+    description: '쪽지 내용',
+    example: '너의 장점은 솔직하다는 거야.',
+    required: true,
+  })
+  @IsString()
+  @Length(MESSAGE_CONTENT_MIN, MESSAGE_CONTENT_MAX)
+  content: string;
+
+  @ApiProperty({
+    description: '질문 id (질문 쪽지를 보낼 때만 필요, 감정 id와 중복 사용 불가)',
+    example: '1',
+    required: false,
+  })
+  @IsOptional()
+  @IsBigIntIdString()
+  questionId?: string;
+
+  @ApiProperty({
+    description: '감정 id (감정 쪽지를 보낼 때만 필요, 질문 id와 중복 사용 불가)',
+    example: '1',
+    required: false,
+  })
+  @IsOptional()
+  @IsBigIntIdString()
+  emotionId?: string;
+}
+
+export class ResponseCreateMessageDto {
+  @ApiProperty({
+    description: '생성된 쪽지의 id',
+    example: '1',
+  })
+  messageId: string;
+}

--- a/src/modules/messages/dto/create-message.dto.ts
+++ b/src/modules/messages/dto/create-message.dto.ts
@@ -1,6 +1,6 @@
 import { IsBigIntIdString } from '@common/decorators/is-bigint-id-string.decorator';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, Length } from 'class-validator';
+import { IsIn, IsOptional, IsString, Length } from 'class-validator';
 import { MESSAGE_CONTENT_MAX, MESSAGE_CONTENT_MIN } from '../constants/messages.constant';
 
 export class CreateMessageDto {
@@ -36,7 +36,8 @@ export class CreateMessageDto {
     required: false,
   })
   @IsOptional()
-  @IsBigIntIdString()
+  @IsIn(['1', '2'])
+  //@IsBigIntIdString() - 감정id가 고정된 값이므로 사용하지 않음. 추후 변경될 수 있음
   emotionId?: string;
 }
 

--- a/src/modules/messages/messages.controller.ts
+++ b/src/modules/messages/messages.controller.ts
@@ -1,0 +1,27 @@
+import { GenerateSwaggerApiDoc, UserAuth } from '@common/common.decorator';
+import { response } from '@common/helpers/common.helper';
+import { User } from '@entities/user.entity';
+import { Body, Controller, HttpStatus, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { CreateMessageDto, ResponseCreateMessageDto } from './dto/create-message.dto';
+import { MessagesService } from './messages.service';
+
+@ApiTags('messages')
+@Controller('messages')
+export class MessagesController {
+  constructor(private readonly messagesService: MessagesService) {}
+
+  @GenerateSwaggerApiDoc({
+    summary: '쪽지 전송',
+    description: '쪽지를 전송합니다.',
+    responseType: ResponseCreateMessageDto,
+    responseStatus: HttpStatus.CREATED,
+  })
+  @Post()
+  async createMessage(@Body() createMessageDto: CreateMessageDto, @UserAuth() user: User) {
+    return response(
+      await this.messagesService.createMessage(createMessageDto, user.userId),
+      '쪽지를 성공적으로 전송했습니다.',
+    );
+  }
+}

--- a/src/modules/messages/messages.controller.ts
+++ b/src/modules/messages/messages.controller.ts
@@ -21,7 +21,8 @@ export class MessagesController {
   async createMessage(@Body() createMessageDto: CreateMessageDto, @UserAuth() user: User) {
     return response(
       await this.messagesService.createMessage(createMessageDto, user.userId),
-      '쪽지를 성공적으로 전송했습니다.',
+      '쪽지가 성공적으로 전송되었습니다.',
+      HttpStatus.CREATED,
     );
   }
 }

--- a/src/modules/messages/messages.module.ts
+++ b/src/modules/messages/messages.module.ts
@@ -1,0 +1,17 @@
+import { CustomTypeOrmModule } from '@common/custom-typeorm/custom-typeorm.module';
+import { Module } from '@nestjs/common';
+import { EmotionRepository } from '@repositories/emotion.repository';
+import { MessageRepository } from '@repositories/message.repository';
+import { QuestionRepository } from '@repositories/question.repository';
+import { UserRepository } from '@repositories/user.repository';
+import { MessagesController } from './messages.controller';
+import { MessagesService } from './messages.service';
+
+@Module({
+  imports: [
+    CustomTypeOrmModule.forCustomRepository([MessageRepository, UserRepository, QuestionRepository, EmotionRepository]),
+  ],
+  controllers: [MessagesController],
+  providers: [MessagesService],
+})
+export class MessagesModule {}

--- a/src/modules/messages/messages.service.spec.ts
+++ b/src/modules/messages/messages.service.spec.ts
@@ -1,0 +1,185 @@
+import { Emotion } from '@entities/emotion.entity';
+import { Question } from '@entities/question.entity';
+import { User } from '@entities/user.entity';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { EmotionRepository, MessageRepository, QuestionRepository, UserRepository } from '@repositories/index';
+import { CreateMessageDto } from './dto/create-message.dto';
+import { MessagesService } from './messages.service';
+
+describe('MessagesService', () => {
+  let service: MessagesService;
+  let messageRepository: MessageRepository;
+  let userRepository: UserRepository;
+  let questionRepository: QuestionRepository;
+  let emotionRepository: EmotionRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessagesService,
+        {
+          provide: MessageRepository,
+          useValue: {
+            createQuestionMessage: jest.fn(),
+            createEmotionMessage: jest.fn(),
+          },
+        },
+        {
+          provide: UserRepository,
+          useValue: {
+            findUserById: jest.fn(),
+          },
+        },
+        {
+          provide: QuestionRepository,
+          useValue: {
+            findQuestionById: jest.fn(),
+          },
+        },
+        {
+          provide: EmotionRepository,
+          useValue: {
+            findEmotionById: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MessagesService>(MessagesService);
+    messageRepository = module.get<MessageRepository>(MessageRepository);
+    userRepository = module.get<UserRepository>(UserRepository);
+    questionRepository = module.get<QuestionRepository>(QuestionRepository);
+    emotionRepository = module.get<EmotionRepository>(EmotionRepository);
+  });
+
+  // SECTION: createMessage success case
+  it('questionId가 제공되고 question의 userId와 receiverId가 일치하면 question message를 생성해야 한다', async () => {
+    const createMessageDto: CreateMessageDto = {
+      receiverId: '2',
+      content: 'content',
+      questionId: '3',
+    };
+    const userId = '1';
+
+    jest.spyOn(userRepository, 'findUserById').mockResolvedValue({ userId: '2' } as User); // receiver check
+    jest.spyOn(questionRepository, 'findQuestionById').mockResolvedValue({ questionId: '3', userId: '2' } as Question);
+    jest.spyOn(messageRepository, 'createQuestionMessage').mockResolvedValue('5');
+
+    const result = await service.createMessage(createMessageDto, userId);
+
+    expect(result).toEqual({ messageId: '5' });
+  });
+
+  it('emotionId가 제공되면 emotion message를 생성해야 한다', async () => {
+    const createMessageDto: CreateMessageDto = {
+      receiverId: '2',
+      content: 'content',
+      emotionId: '4',
+    };
+    const userId = '1';
+
+    jest.spyOn(userRepository, 'findUserById').mockResolvedValue({ userId: '2' } as User);
+    jest.spyOn(emotionRepository, 'findEmotionById').mockResolvedValue({ emotionId: '4' } as Emotion);
+    jest.spyOn(messageRepository, 'createEmotionMessage').mockResolvedValue('5');
+
+    const result = await service.createMessage(createMessageDto, userId);
+
+    expect(result).toEqual({ messageId: '5' });
+  });
+  // !SECTION
+
+  // SECTION: createMessage failure case
+
+  it('questionId와 emotionId가 모두 제공되면 BadRequestException', async () => {
+    const createMessageDto: CreateMessageDto = {
+      receiverId: '2',
+      content: 'content',
+      questionId: '3',
+      emotionId: '4',
+    };
+    const userId = '1';
+
+    await expect(service.createMessage(createMessageDto, userId)).rejects.toThrow(BadRequestException);
+  });
+
+  it('questionId와 emotionId가 모두 제공되지 않으면 BadRequestException', async () => {
+    const createMessageDto: CreateMessageDto = {
+      receiverId: '2',
+      content: 'content',
+    };
+    const userId = '1';
+
+    await expect(service.createMessage(createMessageDto, userId)).rejects.toThrow(BadRequestException);
+  });
+
+  it('questionId가 제공되었지만 question이 존재하지 않으면 NotFoundException', async () => {
+    const createMessageDto: CreateMessageDto = {
+      receiverId: '2',
+      content: 'content',
+      questionId: '3',
+    };
+    const userId = '1';
+
+    jest.spyOn(userRepository, 'findUserById').mockResolvedValue({ userId: '2' } as User);
+    jest.spyOn(questionRepository, 'findQuestionById').mockResolvedValue(null);
+
+    await expect(service.createMessage(createMessageDto, userId)).rejects.toThrow(NotFoundException);
+  });
+
+  it('emotionId가 제공되었지만 emotion이 존재하지 않으면 NotFoundException', async () => {
+    const createMessageDto: CreateMessageDto = {
+      receiverId: '2',
+      content: 'content',
+      emotionId: '4',
+    };
+    const userId = '1';
+
+    jest.spyOn(userRepository, 'findUserById').mockResolvedValue({ userId: '2' } as User);
+    jest.spyOn(emotionRepository, 'findEmotionById').mockResolvedValue(null);
+
+    await expect(service.createMessage(createMessageDto, userId)).rejects.toThrow(NotFoundException);
+  });
+
+  it('receiver가 존재하지 않으면 NotFoundException', async () => {
+    const createMessageDto: CreateMessageDto = {
+      receiverId: '2',
+      content: 'content',
+      questionId: '3',
+    };
+    const userId = '1';
+
+    jest.spyOn(userRepository, 'findUserById').mockResolvedValue(null);
+
+    await expect(service.createMessage(createMessageDto, userId)).rejects.toThrow(NotFoundException);
+  });
+
+  it('receiverId가 userId와 같으면 BadRequestException', async () => {
+    const createMessageDto: CreateMessageDto = {
+      receiverId: '1',
+      content: 'content',
+      questionId: '3',
+    };
+    const userId = '1';
+
+    jest.spyOn(userRepository, 'findUserById').mockResolvedValue({ userId: '1' } as User);
+
+    await expect(service.createMessage(createMessageDto, userId)).rejects.toThrow(BadRequestException);
+  });
+
+  it('question의 userId와 receiverId가 일치하지 않으면 BadRequestException', async () => {
+    const createMessageDto: CreateMessageDto = {
+      receiverId: '2',
+      content: 'content',
+      questionId: '3',
+    };
+    const userId = '1';
+
+    jest.spyOn(userRepository, 'findUserById').mockResolvedValue({ userId: '2' } as User);
+    jest.spyOn(questionRepository, 'findQuestionById').mockResolvedValue({ questionId: '3', userId: '3' } as Question);
+
+    await expect(service.createMessage(createMessageDto, userId)).rejects.toThrow(BadRequestException);
+  });
+
+  //!SECTION
+});

--- a/src/modules/messages/messages.service.ts
+++ b/src/modules/messages/messages.service.ts
@@ -12,6 +12,13 @@ export class MessagesService {
     private readonly emotionRepository: EmotionRepository,
   ) {}
 
+  /**
+   * emotionId가 있을 경우 감정 쪽지를 생성하고, questionId가 있을 경우 질문 쪽지를 생성합니다.
+   *
+   * @param createMessageDto receiverId, content, questionId, emotionId를 포함하는 DTO
+   * @param userId 보내는 사람 (로그인한 유저) id
+   * @returns 생성된 쪽지 id
+   */
   async createMessage(createMessageDto: CreateMessageDto, userId: string): Promise<ResponseCreateMessageDto> {
     const { receiverId, content, questionId, emotionId } = createMessageDto;
 
@@ -43,6 +50,13 @@ export class MessagesService {
     return { messageId };
   }
 
+  /**
+   * question 에 대한 쪽지를 생성합니다.
+   *
+   * @param messageData
+   * @param questionId
+   * @returns 생성된 쪽지 id
+   */
   private async createQuestionMessage(messageData: MessageBaseData, questionId: string): Promise<string> {
     const question = await this.questionRepository.findQuestionById(questionId);
     if (!question) {
@@ -55,6 +69,14 @@ export class MessagesService {
     return this.messageRepository.createQuestionMessage({ ...messageData, questionId });
   }
 
+  /**
+   * question 에 속하지 않는 자유 쪽지를 생성합니다.
+   * emotion 1 : 응원과 감사, 2: 솔직한 대화.
+   *
+   * @param messageData \
+   * @param emotionId
+   * @returns
+   */
   private async createEmotionMessage(messageData: MessageBaseData, emotionId: string): Promise<string> {
     const emotion = await this.emotionRepository.findEmotionById(emotionId);
     if (!emotion) {

--- a/src/modules/messages/messages.service.ts
+++ b/src/modules/messages/messages.service.ts
@@ -1,0 +1,66 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { EmotionRepository, MessageRepository, QuestionRepository, UserRepository } from '@repositories/index';
+import { CreateMessageDto, ResponseCreateMessageDto } from './dto/create-message.dto';
+import { MessageBaseData } from './types/messages.type';
+
+@Injectable()
+export class MessagesService {
+  constructor(
+    private readonly messageRepository: MessageRepository,
+    private readonly userRepository: UserRepository,
+    private readonly questionRepository: QuestionRepository,
+    private readonly emotionRepository: EmotionRepository,
+  ) {}
+
+  async createMessage(createMessageDto: CreateMessageDto, userId: string): Promise<ResponseCreateMessageDto> {
+    const { receiverId, content, questionId, emotionId } = createMessageDto;
+
+    if ((questionId && emotionId) || (!questionId && !emotionId)) {
+      throw new BadRequestException('질문 혹은 감정 중 하나의 id를 입력해주세요.');
+    }
+    const user = await this.userRepository.findUserById(receiverId);
+    if (user === null) {
+      throw new NotFoundException('받는 사람이 존재하지 않습니다.');
+    }
+    if (receiverId === userId) {
+      throw new BadRequestException('자신에게 쪽지를 보낼 수 없습니다.');
+    }
+
+    const messageData = {
+      senderId: userId,
+      receiverId,
+      content,
+    };
+
+    let messageId = '';
+    if (questionId) {
+      messageId = await this.createQuestionMessage(messageData, questionId);
+    }
+    if (emotionId) {
+      messageId = await this.createEmotionMessage(messageData, emotionId);
+    }
+
+    return { messageId };
+  }
+
+  private async createQuestionMessage(messageData: MessageBaseData, questionId: string): Promise<string> {
+    const question = await this.questionRepository.findQuestionById(questionId);
+    if (!question) {
+      throw new NotFoundException(`질문이 존재하지 않습니다.: ${questionId}`);
+    }
+    if (question.userId !== messageData.receiverId) {
+      throw new BadRequestException('질문의 수신자와 쪽지의 수신자가 일치하지 않습니다.');
+    }
+
+    return this.messageRepository.createQuestionMessage({ ...messageData, questionId });
+  }
+
+  private async createEmotionMessage(messageData: MessageBaseData, emotionId: string): Promise<string> {
+    const emotion = await this.emotionRepository.findEmotionById(emotionId);
+    if (!emotion) {
+      throw new NotFoundException(`감정이 존재하지 않습니다.: ${emotionId}`);
+    }
+
+    return this.messageRepository.createEmotionMessage({ ...messageData, emotionId });
+  }
+}

--- a/src/modules/messages/types/messages.type.ts
+++ b/src/modules/messages/types/messages.type.ts
@@ -1,0 +1,13 @@
+export type MessageBaseData = {
+  senderId: string;
+  receiverId: string;
+  content: string;
+};
+
+export type createQuestionMessageParam = MessageBaseData & {
+  questionId: string;
+};
+
+export type createEmotionMessageParam = MessageBaseData & {
+  emotionId: string;
+};

--- a/src/modules/messages/types/messages.type.ts
+++ b/src/modules/messages/types/messages.type.ts
@@ -4,10 +4,14 @@ export type MessageBaseData = {
   content: string;
 };
 
-export type createQuestionMessageParam = MessageBaseData & {
+export type CreateQuestionMessageParam = MessageBaseData & {
   questionId: string;
+  // never는 값을 허용하지 않는 타입이지만, optional 연산자가 없으면 속성이 존재해야하기 때문에 모순이 발생
+  // optional 연산자를 사용해서 emotion id가 존재하지 않아야함을 명시.
+  emotionId?: never;
 };
 
-export type createEmotionMessageParam = MessageBaseData & {
+export type CreateEmotionMessageParam = MessageBaseData & {
   emotionId: string;
+  questionId?: never;
 };

--- a/src/modules/questions/questions.module.ts
+++ b/src/modules/questions/questions.module.ts
@@ -2,9 +2,9 @@ import { Module } from '@nestjs/common';
 
 import { CustomTypeOrmModule } from '@common/custom-typeorm/custom-typeorm.module';
 
+import { QuestionRepository } from '@repositories/question.repository';
 import { QuestionsController } from './questions.controller';
 import { QuestionsService } from './questions.service';
-import { QuestionRepository } from './repository/question.repository';
 
 @Module({
   imports: [CustomTypeOrmModule.forCustomRepository([QuestionRepository])],

--- a/src/modules/questions/questions.service.spec.ts
+++ b/src/modules/questions/questions.service.spec.ts
@@ -1,9 +1,9 @@
 import { ConflictException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { QuestionRepository } from '@repositories/question.repository';
 import { QUESTION_COUNT_LIMIT } from './constants/question.constant';
 import { CreateQuestionDto } from './dto/create-question.dto';
 import { QuestionsService } from './questions.service';
-import { QuestionRepository } from './repository/question.repository';
 
 describe('QuestionsService', () => {
   let service: QuestionsService;

--- a/src/modules/questions/questions.service.ts
+++ b/src/modules/questions/questions.service.ts
@@ -1,7 +1,8 @@
+import { Question } from '@entities/question.entity';
 import { ConflictException, Injectable } from '@nestjs/common';
+import { QuestionRepository } from '@repositories/question.repository';
 import { QUESTION_COUNT_LIMIT } from './constants/question.constant';
 import { CreateQuestionDto } from './dto/create-question.dto';
-import { QuestionRepository } from './repository/question.repository';
 
 @Injectable()
 export class QuestionsService {
@@ -21,5 +22,9 @@ export class QuestionsService {
       isHidden: isHidden,
     });
     return { questionId };
+  }
+
+  async getQuestionById(id: string): Promise<Question | null> {
+    return this.questionRepository.findQuestionById(id);
   }
 }

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -2,8 +2,8 @@ import { Module } from '@nestjs/common';
 
 import { CustomTypeOrmModule } from '@common/custom-typeorm/custom-typeorm.module';
 import { LoggerModule } from '@logger/logger.module';
+import { UserRepository } from '@repositories/user.repository';
 
-import { UserRepository } from './repository/user.repository';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -1,8 +1,10 @@
-import { GoogleUser } from '@common/types/google-user.type';
-import { User } from '@entities/user.entity';
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { UserRepository } from './repository/user.repository';
+
+import { GoogleUser } from '@common/types/google-user.type';
+import { User } from '@entities/user.entity';
+import { UserRepository } from '@repositories/user.repository';
+
 import { LoginType } from './users.constants';
 import { UsersService } from './users.service';
 
@@ -17,9 +19,9 @@ describe('UsersService', () => {
         {
           provide: UserRepository,
           useValue: {
-            getUserByEmail: jest.fn(),
+            findUserByEmail: jest.fn(),
             insert: jest.fn(),
-            getUserById: jest.fn(),
+            findUserById: jest.fn(),
             createUser: jest.fn(),
           },
         },
@@ -37,13 +39,13 @@ describe('UsersService', () => {
         displayName: 'John Doe',
       };
 
-      jest.spyOn(repository, 'getUserByEmail').mockResolvedValue(null);
+      jest.spyOn(repository, 'findUserByEmail').mockResolvedValue(null);
       jest.spyOn(repository, 'insert').mockResolvedValue({ identifiers: [{ id: '1' }], generatedMaps: [], raw: [] });
       jest.spyOn(repository, 'createUser').mockResolvedValue('1');
 
       const result = await service.createOrGetGoogleUser(googleUser);
 
-      expect(repository.getUserByEmail).toHaveBeenCalledWith('test@example.com');
+      expect(repository.findUserByEmail).toHaveBeenCalledWith('test@example.com');
       expect(repository.createUser).toHaveBeenCalledWith('test@example.com', 'John Doe', LoginType.GOOGLE);
       expect(result).toEqual({ userId: '1', email: 'test@example.com' });
     });
@@ -61,7 +63,7 @@ describe('UsersService', () => {
         loginType: LoginType.KAKAO,
       } as User;
 
-      jest.spyOn(repository, 'getUserByEmail').mockResolvedValue(existingUser);
+      jest.spyOn(repository, 'findUserByEmail').mockResolvedValue(existingUser);
 
       await expect(service.createOrGetGoogleUser(googleUser)).rejects.toThrow(ConflictException);
     });
@@ -77,18 +79,18 @@ describe('UsersService', () => {
         loginType: LoginType.GOOGLE,
       } as User;
 
-      jest.spyOn(repository, 'getUserById').mockResolvedValue(user);
+      jest.spyOn(repository, 'findUserById').mockResolvedValue(user);
 
       const result = await service.getNicknameById(userId);
 
       expect(result).toEqual({ userId: '1', nickname: 'John Doe' });
-      expect(repository.getUserById).toHaveBeenCalledWith(userId);
+      expect(repository.findUserById).toHaveBeenCalledWith(userId);
     });
 
     it('user id가 없으면 Not Found exception', async () => {
       const userId = '1';
 
-      jest.spyOn(repository, 'getUserById').mockResolvedValue(null);
+      jest.spyOn(repository, 'findUserById').mockResolvedValue(null);
 
       await expect(service.getNicknameById(userId)).rejects.toThrow(NotFoundException);
     });
@@ -104,18 +106,18 @@ describe('UsersService', () => {
         loginType: LoginType.GOOGLE,
       } as User;
 
-      jest.spyOn(repository, 'getUserByEmail').mockResolvedValue(user);
+      jest.spyOn(repository, 'findUserByEmail').mockResolvedValue(user);
 
       const result = await service.getUserByEmail(email);
 
       expect(result).toEqual(user);
-      expect(repository.getUserByEmail).toHaveBeenCalledWith(email);
+      expect(repository.findUserByEmail).toHaveBeenCalledWith(email);
     });
 
     it('유저가 없으면 null 반환', async () => {
       const email = 'test@example.com';
 
-      jest.spyOn(repository, 'getUserByEmail').mockResolvedValue(null);
+      jest.spyOn(repository, 'findUserByEmail').mockResolvedValue(null);
       const result = await service.getUserByEmail(email);
 
       expect(result).toBeNull();
@@ -132,18 +134,18 @@ describe('UsersService', () => {
         loginType: LoginType.GOOGLE,
       } as User;
 
-      jest.spyOn(repository, 'getUserById').mockResolvedValue(user);
+      jest.spyOn(repository, 'findUserById').mockResolvedValue(user);
 
       const result = await service.getUserById(userId);
 
       expect(result).toEqual(user);
-      expect(repository.getUserById).toHaveBeenCalledWith(userId);
+      expect(repository.findUserById).toHaveBeenCalledWith(userId);
     });
 
     it('유저가 없으면 null 반환', async () => {
       const userId = '1';
 
-      jest.spyOn(repository, 'getUserById').mockResolvedValue(null);
+      jest.spyOn(repository, 'findUserById').mockResolvedValue(null);
       const result = await service.getUserById(userId);
 
       expect(result).toBeNull();

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -2,7 +2,7 @@ import { ConflictException, Injectable, NotFoundException } from '@nestjs/common
 
 import { GoogleUser } from '@common/types/google-user.type';
 import { User } from '@entities/user.entity';
-import { UserRepository } from '@modules/users/repository/user.repository';
+import { UserRepository } from '@repositories/user.repository';
 
 import { ResponseGetUserNicknameDto } from './dto/get-user-nickname.dto';
 import { LoginType } from './users.constants';
@@ -38,7 +38,7 @@ export class UsersService {
    * @returns
    */
   async getNicknameById(userId: string): Promise<ResponseGetUserNicknameDto> {
-    const user = await this.userRepository.getUserById(userId);
+    const user = await this.userRepository.findUserById(userId);
     if (user === null) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
@@ -52,7 +52,7 @@ export class UsersService {
    * @returns
    */
   async getUserByEmail(email: string): Promise<User | null> {
-    return this.userRepository.getUserByEmail(email);
+    return this.userRepository.findUserByEmail(email);
   }
 
   /**
@@ -62,6 +62,6 @@ export class UsersService {
    * @returns
    */
   async getUserById(id: string): Promise<User | null> {
-    return this.userRepository.getUserById(id);
+    return this.userRepository.findUserById(id);
   }
 }

--- a/src/repositories/emotion.repository.ts
+++ b/src/repositories/emotion.repository.ts
@@ -1,0 +1,11 @@
+import { Repository } from 'typeorm';
+
+import { CustomEntityRepository } from '@common/custom-typeorm/custom-typeorm.decorator';
+import { Emotion } from '@entities/emotion.entity';
+
+@CustomEntityRepository(Emotion)
+export class EmotionRepository extends Repository<Emotion> {
+  findEmotionById(id: string) {
+    return this.findOne({ where: { emotionId: id } });
+  }
+}

--- a/src/repositories/emotion.repository.ts
+++ b/src/repositories/emotion.repository.ts
@@ -5,7 +5,7 @@ import { Emotion } from '@entities/emotion.entity';
 
 @CustomEntityRepository(Emotion)
 export class EmotionRepository extends Repository<Emotion> {
-  findEmotionById(id: string) {
+  async findEmotionById(id: string): Promise<Emotion | null> {
     return this.findOne({ where: { emotionId: id } });
   }
 }

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,0 +1,5 @@
+// repositories/index.ts
+export { MessageRepository } from './message.repository';
+export { UserRepository } from './user.repository';
+export { QuestionRepository } from './question.repository';
+export { EmotionRepository } from './emotion.repository';

--- a/src/repositories/message-statistic.repository.ts
+++ b/src/repositories/message-statistic.repository.ts
@@ -1,0 +1,7 @@
+import { Repository } from 'typeorm';
+
+import { CustomEntityRepository } from '@common/custom-typeorm/custom-typeorm.decorator';
+import { MessageStatistic } from '@entities/message-statistic.entity';
+
+@CustomEntityRepository(MessageStatistic)
+export class MessageStatisticRepository extends Repository<MessageStatistic> {}

--- a/src/repositories/message.repository.ts
+++ b/src/repositories/message.repository.ts
@@ -1,0 +1,7 @@
+import { Repository } from 'typeorm';
+
+import { CustomEntityRepository } from '@common/custom-typeorm/custom-typeorm.decorator';
+import { Message } from '@entities/message.entity';
+
+@CustomEntityRepository(Message)
+export class MessageRepository extends Repository<Message> {}

--- a/src/repositories/message.repository.ts
+++ b/src/repositories/message.repository.ts
@@ -1,7 +1,61 @@
 import { Repository } from 'typeorm';
 
 import { CustomEntityRepository } from '@common/custom-typeorm/custom-typeorm.decorator';
+import { MessageStatistic } from '@entities/message-statistic.entity';
 import { Message } from '@entities/message.entity';
-
+import { createEmotionMessageParam, createQuestionMessageParam } from '@modules/messages/types/messages.type';
 @CustomEntityRepository(Message)
-export class MessageRepository extends Repository<Message> {}
+export class MessageRepository extends Repository<Message> {
+  /**
+   * question에 관련된 쪽지를 생성하고 생성된 쪽지의 id를 반환합니다.
+   *
+   * @param message senderId, receiverId, questionId, content
+   * @returns 생성된 쪽지의 id
+   */
+  async createQuestionMessage(message: createQuestionMessageParam): Promise<string> {
+    return this.createMessage(message);
+  }
+
+  /**
+   * emotion에 관련된 쪽지를 생성하고 생성된 쪽지의 id를 반환합니다.
+   *
+   * @param message senderId, receiverId, emotionId, content
+   * @returns
+   */
+  async createEmotionMessage(message: createEmotionMessageParam): Promise<string> {
+    return this.createMessage(message);
+  }
+
+  /**
+   * 쪽지를 생성하고 생성된 쪽지의 id를 반환합니다.
+   *
+   * @param param senderId, receiverId, content와 함께 questionId 또는 emotionId
+   * @returns 생성된 쪽지의 id
+   */
+  private async createMessage(message: createQuestionMessageParam | createEmotionMessageParam): Promise<string> {
+    const { senderId, receiverId } = message;
+
+    const messageId = await this.manager.transaction(async (manager) => {
+      const messageResult = await manager.getRepository(Message).insert(message);
+
+      // sender의 sentMessageCount를 1 증가시키고, receiver의 receivedMessageCount와 unreadMessageCount를 1 증가시킵니다.
+      // 순서 상관없으므로 Promise.all을 사용합니다.
+      // NOTE: transaction 정말 필요한지? 통계 연산이 실패했다고 쪽지 생성이 실패해야 하는가?
+      await Promise.all([
+        manager
+          .getRepository(MessageStatistic)
+          .update({ userId: senderId }, { sentMessageCount: () => 'sent_message_count + 1' }),
+        manager.getRepository(MessageStatistic).update(
+          { userId: receiverId },
+          {
+            receivedMessageCount: () => 'received_message_count + 1',
+            unreadMessageCount: () => 'unread_message_count + 1',
+          },
+        ),
+      ]);
+
+      return messageResult.identifiers[0].messageId;
+    });
+    return messageId;
+  }
+}

--- a/src/repositories/message.repository.ts
+++ b/src/repositories/message.repository.ts
@@ -3,7 +3,7 @@ import { Repository } from 'typeorm';
 import { CustomEntityRepository } from '@common/custom-typeorm/custom-typeorm.decorator';
 import { MessageStatistic } from '@entities/message-statistic.entity';
 import { Message } from '@entities/message.entity';
-import { createEmotionMessageParam, createQuestionMessageParam } from '@modules/messages/types/messages.type';
+import { CreateEmotionMessageParam, CreateQuestionMessageParam } from '@modules/messages/types/messages.type';
 @CustomEntityRepository(Message)
 export class MessageRepository extends Repository<Message> {
   /**
@@ -12,7 +12,7 @@ export class MessageRepository extends Repository<Message> {
    * @param message senderId, receiverId, questionId, content
    * @returns 생성된 쪽지의 id
    */
-  async createQuestionMessage(message: createQuestionMessageParam): Promise<string> {
+  async createQuestionMessage(message: CreateQuestionMessageParam): Promise<string> {
     return this.createMessage(message);
   }
 
@@ -22,7 +22,7 @@ export class MessageRepository extends Repository<Message> {
    * @param message senderId, receiverId, emotionId, content
    * @returns
    */
-  async createEmotionMessage(message: createEmotionMessageParam): Promise<string> {
+  async createEmotionMessage(message: CreateEmotionMessageParam): Promise<string> {
     return this.createMessage(message);
   }
 
@@ -32,7 +32,7 @@ export class MessageRepository extends Repository<Message> {
    * @param param senderId, receiverId, content와 함께 questionId 또는 emotionId
    * @returns 생성된 쪽지의 id
    */
-  private async createMessage(message: createQuestionMessageParam | createEmotionMessageParam): Promise<string> {
+  private async createMessage(message: CreateQuestionMessageParam | CreateEmotionMessageParam): Promise<string> {
     const { senderId, receiverId } = message;
 
     const messageId = await this.manager.transaction(async (manager) => {

--- a/src/repositories/question.repository.ts
+++ b/src/repositories/question.repository.ts
@@ -25,4 +25,8 @@ export class QuestionRepository extends Repository<Question> {
   async countQuestionsByUserId(userId: string): Promise<number> {
     return this.count({ where: { userId } });
   }
+
+  async findQuestionById(questionId: string): Promise<Question | null> {
+    return this.findOne({ where: { questionId } });
+  }
 }

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm';
 
 import { CustomEntityRepository } from '@common/custom-typeorm/custom-typeorm.decorator';
+import { MessageStatistic } from '@entities/message-statistic.entity';
 import { User } from '@entities/user.entity';
 
 @CustomEntityRepository(User)
@@ -14,8 +15,23 @@ export class UserRepository extends Repository<User> {
    * @returns 생성한 user의 userId
    */
   async createUser(email: string, nickname: string, loginType: number): Promise<string> {
-    const result = await this.insert({ email, nickname, loginType });
-    return result.identifiers[0].userId;
+    return this.manager.transaction(async (transactionalEntityManager) => {
+      // 1. User 생성
+      const userResult = await transactionalEntityManager.insert(User, {
+        email,
+        nickname,
+        loginType,
+      });
+
+      const userId = userResult.identifiers[0].userId;
+
+      // 2. MessageStatistics 생성 (user와 1:1 관계)
+      await transactionalEntityManager.insert(MessageStatistic, {
+        userId: userId,
+      });
+
+      return userId;
+    });
   }
 
   // 유저 이메일 기준으로 조회

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -19,11 +19,11 @@ export class UserRepository extends Repository<User> {
   }
 
   // 유저 이메일 기준으로 조회
-  async getUserByEmail(email: string): Promise<User | null> {
+  async findUserByEmail(email: string): Promise<User | null> {
     return await this.findOne({ where: { email } });
   }
 
-  async getUserById(id: string): Promise<User | null> {
+  async findUserById(id: string): Promise<User | null> {
     return this.findOne({ where: { userId: id } });
   }
 }

--- a/test/helpers/create-testing-app.helper.ts
+++ b/test/helpers/create-testing-app.helper.ts
@@ -76,35 +76,35 @@ export const createTestingApp = async (
   const existingUser = await userRepository.findOneBy({ userId: loginUser.userId });
   const existingTargetUser = await userRepository.findOneBy({ userId: targetUser.userId });
 
-  if (!existingUser) {
-    await userRepository.insert(loginUser);
-  }
-  if (!existingTargetUser) {
-    await userRepository.insert(targetUser);
-  }
+  await dataSource.manager.transaction(async (manager) => {
+    if (!existingUser) {
+      await manager.insert(User, loginUser);
+    }
+    if (!existingTargetUser) {
+      await manager.insert(User, targetUser);
+    }
 
-  // create or update message statistics
-  const mstRepository = dataSource.getRepository(MessageStatistic);
-
-  await mstRepository.upsert(
-    [
-      {
-        userId: loginUser.userId,
-        receivedMessageCount: 0,
-        sentMessageCount: 0,
-        unreadMessageCount: 0,
-        unreadReactionCount: 0,
-      },
-      {
-        userId: targetUser.userId,
-        receivedMessageCount: 0,
-        sentMessageCount: 0,
-        unreadMessageCount: 0,
-        unreadReactionCount: 0,
-      },
-    ],
-    ['userId'], // conflict key
-  );
+    await manager.upsert(
+      MessageStatistic,
+      [
+        {
+          userId: loginUser.userId,
+          receivedMessageCount: 0,
+          sentMessageCount: 0,
+          unreadMessageCount: 0,
+          unreadReactionCount: 0,
+        },
+        {
+          userId: targetUser.userId,
+          receivedMessageCount: 0,
+          sentMessageCount: 0,
+          unreadMessageCount: 0,
+          unreadReactionCount: 0,
+        },
+      ],
+      ['userId'],
+    );
+  });
 
   return { app, dataSource };
 };

--- a/test/helpers/create-testing-app.helper.ts
+++ b/test/helpers/create-testing-app.helper.ts
@@ -1,0 +1,110 @@
+import { AllExceptionsFilter } from '@common/filters/all-exception.filter';
+import { JwtAuthGuard } from '@common/guards/jwt-auth.guard';
+import { LoggingInterceptor } from '@common/interceptors/logging.interceptor';
+import { MessageStatistic } from '@entities/message-statistic.entity';
+import { User } from '@entities/user.entity';
+import { CustomLogger } from '@logger/custom-logger.service';
+import { ExecutionContext, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource } from 'typeorm';
+import { AppModule } from '../../src/app.module';
+
+export type TestUser = {
+  userId: string;
+  email: string;
+  nickname: string;
+  loginType: number;
+};
+
+/**
+ * 공통 테스트용 앱 생성 함수
+ * @param testUser
+ * @returns
+ */
+export const createTestingApp = async (
+  testUser: TestUser[] = [
+    {
+      userId: '1',
+      email: 'test@example.com',
+      nickname: 'loginUser',
+      loginType: 1,
+    },
+    {
+      userId: '2',
+      email: 'test2@exmple.com',
+      nickname: 'targetUser',
+      loginType: 1,
+    },
+  ],
+): Promise<{ app: INestApplication; dataSource: DataSource }> => {
+  const loginUser = testUser[0];
+  const targetUser = testUser[1];
+
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [AppModule],
+  })
+    .overrideProvider(JwtAuthGuard)
+    .useValue({
+      canActivate: (context: ExecutionContext) => {
+        const request = context.switchToHttp().getRequest();
+        request.user = {
+          userId: loginUser.userId,
+          email: loginUser.email,
+        };
+        return true;
+      },
+    })
+    .compile();
+
+  const app = moduleFixture.createNestApplication();
+  const dataSource = moduleFixture.get(DataSource);
+  const logger = app.get(CustomLogger);
+
+  app.useLogger(logger);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
+  app.useGlobalFilters(new AllExceptionsFilter(logger));
+  app.useGlobalInterceptors(new LoggingInterceptor(logger));
+
+  // create or check test user
+  const userRepository = dataSource.getRepository(User);
+  const existingUser = await userRepository.findOneBy({ userId: loginUser.userId });
+  const existingTargetUser = await userRepository.findOneBy({ userId: targetUser.userId });
+
+  if (!existingUser) {
+    await userRepository.insert(loginUser);
+  }
+  if (!existingTargetUser) {
+    await userRepository.insert(targetUser);
+  }
+
+  // create or update message statistics
+  const mstRepository = dataSource.getRepository(MessageStatistic);
+
+  await mstRepository.upsert(
+    [
+      {
+        userId: loginUser.userId,
+        receivedMessageCount: 0,
+        sentMessageCount: 0,
+        unreadMessageCount: 0,
+        unreadReactionCount: 0,
+      },
+      {
+        userId: targetUser.userId,
+        receivedMessageCount: 0,
+        sentMessageCount: 0,
+        unreadMessageCount: 0,
+        unreadReactionCount: 0,
+      },
+    ],
+    ['userId'], // conflict key
+  );
+
+  return { app, dataSource };
+};

--- a/test/messages.e2e-spec.ts
+++ b/test/messages.e2e-spec.ts
@@ -1,0 +1,122 @@
+import { AllExceptionsFilter } from '@common/filters/all-exception.filter';
+import { JwtAuthGuard } from '@common/guards/jwt-auth.guard';
+import { LoggingInterceptor } from '@common/interceptors/logging.interceptor';
+import { Emotion } from '@entities/emotion.entity';
+import { Question } from '@entities/question.entity';
+import { CustomLogger } from '@logger/custom-logger.service';
+import { CreateMessageDto } from '@modules/messages/dto/create-message.dto';
+import { ExecutionContext, HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from 'src/app.module';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import { createTestingApp } from './helpers/create-testing-app.helper';
+
+describe('Messages API test', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  const loginUserId = '1'; // 테스트용 유저 ID
+  const targetUserId = '2'; // 테스트용 유저 ID
+  let targetQuestionIds: string[];
+
+  beforeAll(async () => {
+    const testApp = await createTestingApp();
+    app = testApp.app;
+    dataSource = testApp.dataSource;
+    await app.init();
+
+    const emotionRepository = dataSource.getRepository(Emotion);
+    const emotions = await emotionRepository.find();
+    if (emotions.length === 0) {
+      await emotionRepository.insert([
+        { emotionId: '1', name: '응원과 감사', emoji: '🌟' },
+        { emotionId: '2', name: '솔직한 대화', emoji: '🤝' },
+      ]);
+    }
+
+    const questionRepository = dataSource.getRepository(Question);
+    const questions = await questionRepository.find({ where: { userId: targetUserId } });
+    targetQuestionIds = questions.map((item) => item.questionId);
+    if (questions.length === 0) {
+      const result = await questionRepository.insert([
+        { userId: targetUserId, content: '질문1', isHidden: false },
+        { userId: targetUserId, content: '질문2', isHidden: false },
+      ]);
+      targetQuestionIds = result.identifiers.map((item) => item.questionId);
+    }
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy(); // 데이터베이스 연결 종료
+    await app.close(); // 애플리케이션 종료
+  });
+
+  describe('POST /messages', () => {
+    it('question 에 쪽지 보내기', () => {
+      const createMessageDto: CreateMessageDto = {
+        receiverId: targetUserId,
+        content: '테스트 메시지입니다.',
+        questionId: targetQuestionIds[0],
+      };
+
+      return request(app.getHttpServer())
+        .post('/messages')
+        .send(createMessageDto)
+        .expect(HttpStatus.CREATED)
+        .expect((response) => {
+          expect(response.body).toHaveProperty('data');
+          expect(response.body).toHaveProperty('message');
+          expect(response.body).toHaveProperty('status');
+
+          expect(response.body.status).toBe(HttpStatus.CREATED);
+          expect(response.body.message).toBe('쪽지가 성공적으로 전송되었습니다.');
+
+          // MessageResponseDto 형식 검증
+          expect(response.body.data).toHaveProperty('messageId');
+          expect(typeof response.body.data.messageId).toBe('string');
+        });
+    });
+
+    it('emotion 에 쪽지 보내기', () => {
+      const createMessageDto: CreateMessageDto = {
+        receiverId: targetUserId,
+        content: '테스트 메시지입니다.',
+        emotionId: '1',
+      };
+
+      return request(app.getHttpServer())
+        .post('/messages')
+        .send(createMessageDto)
+        .expect(HttpStatus.CREATED)
+        .expect((response) => {
+          expect(response.body).toHaveProperty('data');
+          expect(response.body).toHaveProperty('message');
+          expect(response.body).toHaveProperty('status');
+
+          expect(response.body.status).toBe(HttpStatus.CREATED);
+          expect(response.body.message).toBe('쪽지가 성공적으로 전송되었습니다.');
+
+          // MessageResponseDto 형식 검증
+          expect(response.body.data).toHaveProperty('messageId');
+          expect(typeof response.body.data.messageId).toBe('string');
+        });
+    });
+
+    // 1, 2 외의 emotionId를 전송하는 경우
+    it('없는 emotion에 쪽지 보내면 Not Found', () => {
+      const createMessageDto: CreateMessageDto = {
+        receiverId: targetUserId,
+        content: '테스트 메시지입니다.',
+        emotionId: '3',
+      };
+
+      return request(app.getHttpServer())
+        .post('/messages')
+        .send(createMessageDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .expect((response) => {
+          expect(response.body).toHaveProperty('message');
+        });
+    });
+  });
+});

--- a/test/messages.e2e-spec.ts
+++ b/test/messages.e2e-spec.ts
@@ -103,7 +103,7 @@ describe('Messages API test', () => {
     });
 
     // 1, 2 외의 emotionId를 전송하는 경우
-    it('없는 emotion에 쪽지 보내면 Not Found', () => {
+    it('존재하지 않는 감정에 쪽지 전송 실패', () => {
       const createMessageDto: CreateMessageDto = {
         receiverId: targetUserId,
         content: '테스트 메시지입니다.',

--- a/test/questions.e2e-spec.ts
+++ b/test/questions.e2e-spec.ts
@@ -53,6 +53,7 @@ describe('Questions API test', () => {
     const userRepository = dataSource.getRepository('users');
     const existingUser = await userRepository.findOneBy({ userId: testUserId });
 
+    // TODO: insert message statistics, 공통 setting 분리
     if (!existingUser) {
       await userRepository.insert({
         userId: testUserId,

--- a/test/questions.e2e-spec.ts
+++ b/test/questions.e2e-spec.ts
@@ -1,14 +1,10 @@
-import { AllExceptionsFilter } from '@common/filters/all-exception.filter';
-import { JwtAuthGuard } from '@common/guards/jwt-auth.guard';
-import { LoggingInterceptor } from '@common/interceptors/logging.interceptor';
-import { CustomLogger } from '@logger/custom-logger.service';
 import { QUESTION_COUNT_LIMIT } from '@modules/questions/constants/question.constant';
 import { CreateQuestionDto } from '@modules/questions/dto/create-question.dto';
-import { ExecutionContext, INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { DataSource } from 'typeorm';
-import { AppModule } from './../src/app.module';
+
+import { createTestingApp } from './helpers/create-testing-app.helper';
 
 describe('Questions API test', () => {
   let app: INestApplication;
@@ -17,51 +13,11 @@ describe('Questions API test', () => {
   const testUserId = '1'; // 테스트용 유저 ID
 
   beforeAll(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    })
-      .overrideProvider(JwtAuthGuard)
-      .useValue({
-        canActivate: (context: ExecutionContext) => {
-          const request = context.switchToHttp().getRequest();
-          request.user = {
-            userId: '1',
-            email: 'test@example.com',
-          };
-          return true; // 모든 요청을 허용
-        },
-      })
-      .compile();
-
-    app = moduleFixture.createNestApplication();
-    dataSource = moduleFixture.get(DataSource);
-
-    const logger = app.get(CustomLogger);
-    app.useLogger(logger);
-    app.useGlobalPipes(
-      new ValidationPipe({
-        transform: true,
-        whitelist: true,
-        forbidNonWhitelisted: true,
-      }),
-    );
-    app.useGlobalFilters(new AllExceptionsFilter(logger));
-    app.useGlobalInterceptors(new LoggingInterceptor(logger));
-
+    // 1, 2 번 유저 생성
+    const testApp = await createTestingApp();
+    app = testApp.app;
+    dataSource = testApp.dataSource;
     await app.init();
-
-    const userRepository = dataSource.getRepository('users');
-    const existingUser = await userRepository.findOneBy({ userId: testUserId });
-
-    // TODO: insert message statistics, 공통 setting 분리
-    if (!existingUser) {
-      await userRepository.insert({
-        userId: testUserId,
-        email: 'test@example.com',
-        nickname: 'TestUser',
-        loginType: 1,
-      });
-    }
 
     const questionRepository = dataSource.getRepository('questions');
     await questionRepository.delete({ userId: testUserId });
@@ -69,6 +25,11 @@ describe('Questions API test', () => {
 
   beforeEach(() => {
     createdQuestionIds = []; // 테스트 시작 전 초기화
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy(); // 데이터베이스 연결 종료
+    await app.close(); // 애플리케이션 종료
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary
- `POST /v2/message` 쪽지 전송 API 구현.
  - emotion, question 두 가지 속성에 대한 쪽지를 보낼 수 있습니다.
## Describe your changes
- message module, service, controller, repository 추가.
- createMessage에 대한 unit test, `POST /v2/messages`에 대한 API test.
- 기존 bigint 타입 id 검증 pipe와 동일한 로직으로 dto property를 검증하는 `IsBigIntIdString` 데코레이터 구현
  * [`src/common/decorators/is-bigint-id-string.decorator.ts`](diffhunk://#diff-8d6bed07512edc7556bf0631685fd357f026d7fcca3ace29ec44a42fb53ab62eR1-R37)
  - 공통된 validation 을 `bigint-string-validator` 함수로 분리. 
    - [`src/common/validators/bigint-string.validator.ts`](diffhunk://#diff-27af6850db31decb48b1163fdb7e0b8d9fa28ff730a19e955bc96ca8e184ab31R1-R24)
- 메소드 간 통일성을 위해서 `getUserById` -> `findUserById`로 repository 메소드 명 변경

## Issue number and link
- close #19 
- close #22 

---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

- **신규 기능**
	- 메시지 생성과 관련된 `MessagesModule`이 추가되었습니다.
	- 메시지 생성에 필요한 데이터 전송 객체(`CreateMessageDto`, `ResponseCreateMessageDto`)가 도입되었습니다.
	- 메시지 관련 HTTP 요청을 처리하는 `MessagesController`가 추가되었습니다.
	- 사용자 및 메시지 통계 관리를 위한 새로운 리포지토리(`EmotionRepository`, `MessageRepository`, `UserRepository`)가 도입되었습니다.
	- 질문 및 감정에 따른 메시지 생성을 지원하는 서비스(`MessagesService`)가 추가되었습니다.
	- BigInt ID 형식 검증을 위한 새로운 커스텀 검증 데코레이터가 추가되었습니다.

- **버그 수정**
	- 유효하지 않은 ID 형식에 대한 검증 로직이 개선되었습니다.

- **문서화**
	- API 문서화를 위한 Swagger 지원이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

