### PR TITLE
✨ [Feature] get my questions API 

### DIFF
--- a/database/init-scripts/init.sql
+++ b/database/init-scripts/init.sql
@@ -1,0 +1,225 @@
+-- 변경 가능
+CREATE SCHEMA keepintouch_dev;
+SET search_path TO keepintouch_dev;
+
+ALTER DATABASE new_keep SET search_path TO keepintouch_dev;
+
+CREATE SEQUENCE users_user_id_seq
+    INCREMENT BY 1
+    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    START WITH 1
+    CACHE 1
+    NO CYCLE;
+
+CREATE SEQUENCE emotions_emotion_id_seq
+    INCREMENT BY 1
+    MINVALUE 1
+    MAXVALUE 2147483647
+    START WITH 1
+    CACHE 1
+    NO CYCLE;
+
+CREATE SEQUENCE questions_question_id_seq
+    INCREMENT BY 1
+    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    START WITH 1
+    CACHE 1
+    NO CYCLE;
+
+CREATE SEQUENCE messages_message_id_seq
+    INCREMENT BY 1
+    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    START WITH 1
+    CACHE 1
+    NO CYCLE;
+
+CREATE SEQUENCE reaction_templates_reaction_template_id_seq
+    INCREMENT BY 1
+    MINVALUE 1
+    MAXVALUE 2147483647
+    START WITH 1
+    CACHE 1
+    NO CYCLE;
+
+CREATE SEQUENCE reactions_reaction_id_seq
+    INCREMENT BY 1
+    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    START WITH 1
+    CACHE 1
+    NO CYCLE;
+
+-- Users table
+CREATE TABLE users (
+    user_id bigint NOT NULL DEFAULT nextval('users_user_id_seq'::regclass),
+    email character varying(255) NOT NULL,
+    password character varying(255),
+    nickname character varying(20),
+    age integer,
+    gender character varying(10),
+    login_type smallint NOT NULL,
+    created_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at timestamp(6),
+    CONSTRAINT users_pkey PRIMARY KEY (user_id),
+    CONSTRAINT users_age_check CHECK ((age >= 0)),
+    CONSTRAINT users_email_uq UNIQUE (email)
+);
+
+COMMENT ON COLUMN users.login_type IS '가입 수단에 따른 타입 (email=1, google=2, kakao=3)';
+
+-- Questions table
+CREATE TABLE questions (
+    question_id bigint NOT NULL DEFAULT nextval('questions_question_id_seq'::regclass),
+    user_id bigint NOT NULL,
+    is_hidden boolean NOT NULL DEFAULT false,
+    created_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at timestamp(6),
+    content character varying(140) NOT NULL,
+    CONSTRAINT questions_pkey PRIMARY KEY (question_id)
+);
+
+COMMENT ON TABLE questions IS '질문';
+
+-- Messages table
+CREATE TABLE messages (
+    message_id bigint NOT NULL DEFAULT nextval('messages_message_id_seq'::regclass),
+    sender_id bigint NOT NULL,
+    receiver_id bigint NOT NULL,
+    question_id bigint,
+    content character varying(200) NOT NULL,
+    status smallint NOT NULL DEFAULT 1,
+    read_at timestamp(6),
+    created_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at timestamp(6),
+    emotion_id integer,
+    CONSTRAINT messages_pkey PRIMARY KEY (message_id)
+);
+
+COMMENT ON TABLE messages IS '쪽지. emotion 혹은 question 둘 중 하나만 가질 수 있다.';
+COMMENT ON COLUMN messages.status IS '정상, 신고, 숨김 상태 표시 // 1, 2, 3';
+COMMENT ON COLUMN messages.read_at IS '쪽지 수신자의 읽은시간';
+
+-- Index
+CREATE INDEX messages_created_at_idx ON messages(created_at);
+
+-- Reaction templates table
+CREATE TABLE reaction_templates (
+    reaction_template_id integer NOT NULL DEFAULT nextval('reaction_templates_reaction_template_id_seq'::regclass),
+    emoji character varying(10) NOT NULL,
+    type smallint NOT NULL,
+    content character varying(50) NOT NULL,
+    CONSTRAINT reaction_templates_pkey PRIMARY KEY (reaction_template_id)
+);
+
+COMMENT ON COLUMN reaction_templates.type IS '감사, 사과, 응원, 화해';
+
+-- Reactions table
+CREATE TABLE reactions (
+    reaction_id bigint NOT NULL DEFAULT nextval('reactions_reaction_id_seq'::regclass),
+    message_id bigint NOT NULL,
+    created_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at timestamp(6),
+    reaction_template_id integer NOT NULL,
+    CONSTRAINT reactions_pkey PRIMARY KEY (reaction_id)
+);
+
+-- Message statistics table
+CREATE TABLE message_statistics (
+    user_id bigint NOT NULL,
+    received_message_count integer NOT NULL DEFAULT 0,
+    sent_message_count integer NOT NULL DEFAULT 0,
+    unread_message_count integer NOT NULL DEFAULT 0,
+    unread_reaction_count integer NOT NULL DEFAULT 0,
+    CONSTRAINT message_statistics_pkey PRIMARY KEY (user_id),
+    CONSTRAINT message_statistics_user_id_uq UNIQUE (user_id)
+);
+
+COMMENT ON TABLE message_statistics IS '전체 쪽지, 안읽은 쪽지의 개수를 저장';
+
+-- Emotions table
+CREATE TABLE emotions (
+    name character varying(50) NOT NULL,
+    emoji character varying(10) NOT NULL,
+    emotion_id integer NOT NULL DEFAULT nextval('emotions_emotion_id_seq'::regclass),
+    CONSTRAINT emotions_pkey PRIMARY KEY (emotion_id)
+);
+
+-- Foreign key constraints
+ALTER TABLE questions
+    ADD CONSTRAINT questions_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(user_id)
+    ON DELETE CASCADE;
+
+ALTER TABLE messages
+    ADD CONSTRAINT messages_sender_id_fkey
+    FOREIGN KEY (sender_id) REFERENCES users(user_id)
+    ON DELETE CASCADE;
+
+ALTER TABLE messages
+    ADD CONSTRAINT messages_receiver_id_fkey
+    FOREIGN KEY (receiver_id) REFERENCES users(user_id)
+    ON DELETE CASCADE;
+
+ALTER TABLE messages
+    ADD CONSTRAINT messages_emotion_id_fkey
+    FOREIGN KEY (emotion_id) REFERENCES emotions(emotion_id)
+    ON DELETE SET NULL;
+
+ALTER TABLE messages
+    ADD CONSTRAINT messages_question_id_fkey
+    FOREIGN KEY (question_id) REFERENCES questions(question_id)
+    ON DELETE SET NULL;
+
+ALTER TABLE reactions
+    ADD CONSTRAINT reactions_message_id_fkey
+    FOREIGN KEY (message_id) REFERENCES messages(message_id)
+    ON DELETE CASCADE;
+
+ALTER TABLE reactions
+    ADD CONSTRAINT reactions_reaction_template_id_fkey
+    FOREIGN KEY (reaction_template_id) REFERENCES reaction_templates(reaction_template_id)
+    ON DELETE CASCADE;
+
+ALTER TABLE message_statistics
+    ADD CONSTRAINT message_statistics_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(user_id)
+    ON DELETE CASCADE;
+
+
+-- Insert data into reaction_templates
+INSERT INTO reaction_templates (emoji, type, content)
+VALUES
+    ('😊', 1, '고마워'),
+    ('🥰', 1, '덕분이야'),
+    ('😘', 1, '최고야'),
+    ('🥹', 1, '감동이야'),
+    ('🤭', 1, '너밖에 없어'),
+    ('🥲', 2, '내가 더 잘할게'),
+    ('😔', 2, '잘못했어'),
+    ('🥹', 2, '죄인이오'),
+    ('😭', 2, '반성하는 중'),
+    ('🥺', 2, '미안해'),
+    ('😎', 3, '화이팅'),
+    ('🤩', 3, '멋있어'),
+    ('👏', 3, '고생 많았어'),
+    ('💪', 3, '응원할게'),
+    ('🍀', 3, '행운을 빌어요'),
+    ('☺️', 4, '그럴 수 있지'),
+    ('🤗', 4, '괜찮아'),
+    ('😁', 4, '잘 부탁해'),
+    ('😤', 4, '나한테 잘해'),
+    ('😉', 4, '한 번만 봐줄게');
+
+
+-- Insert data into emotions
+INSERT INTO emotions (name, emoji)
+VALUES
+    ('응원과 감사', '🌟'),
+    ('솔직한 대화', '🤝');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DATABASE}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/data
+      - ./database/init-scripts:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USERNAME} -d ${POSTGRES_DATABASE}"]
       interval: 10s
@@ -44,5 +45,5 @@ services:
       postgres:
         condition: service_healthy
 volumes:
-  postgres_data:
+  pg_data:
   pgadmin_data:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand",
     "test:e2e:cache:clear": "jest --clearCache"
   },
   "dependencies": {

--- a/src/common/common.decorator.ts
+++ b/src/common/common.decorator.ts
@@ -71,7 +71,6 @@ export const GenerateSwaggerApiDoc = (swaggerDocInterface: SwaggerDocInterface) 
     query = [],
     body = {},
   } = swaggerDocInterface;
-  //객체인지 배열인지 구분하여 처리
   const headerOptions = Array.isArray(headers) ? headers : [headers];
 
   if (jwt) methodDecorators.push(ApiBearerAuth('jwt'));
@@ -94,7 +93,7 @@ export const GenerateSwaggerApiDoc = (swaggerDocInterface: SwaggerDocInterface) 
 
   if (!isEmpty(body)) methodDecorators.push(ApiBody(body));
 
-  if (!isUndefined(responseType)) methodDecorators.push(ResponseDtoType(responseType as any, responseStatus));
+  if (!isUndefined(responseType)) methodDecorators.push(ResponseDtoType(responseType, responseStatus));
 
   return applyDecorators(ApiOperation({ summary, description }), ...methodDecorators);
 };

--- a/src/common/common.interface.ts
+++ b/src/common/common.interface.ts
@@ -9,7 +9,7 @@ export interface SwaggerDocInterface {
   // 설명(상세)
   description: string;
   // 응답하는 형태(response-dto)
-  responseType?: Type;
+  responseType?: Type | Type[];
 
   responseStatus?: HttpStatus;
 

--- a/src/common/common.interface.ts
+++ b/src/common/common.interface.ts
@@ -9,7 +9,7 @@ export interface SwaggerDocInterface {
   // 설명(상세)
   description: string;
   // 응답하는 형태(response-dto)
-  responseType?: Type | Type[];
+  responseType?: Type<unknown> | [Type<unknown>];
 
   responseStatus?: HttpStatus;
 

--- a/src/common/decorators/is-bigint-id-string.decorator.ts
+++ b/src/common/decorators/is-bigint-id-string.decorator.ts
@@ -22,7 +22,7 @@ export class IsBigIntIdStringConstraint implements ValidatorConstraintInterface 
  * class validator에서 사용할 BigInt string 유효성 검사 데코레이터
  *
  * @param validationOptions
- * @returns
+ * @returns {Function}
  */
 export function IsBigIntIdString(validationOptions?: ValidationOptions) {
   return (obj: object, propertyName: string) => {

--- a/src/common/decorators/is-bigint-id-string.decorator.ts
+++ b/src/common/decorators/is-bigint-id-string.decorator.ts
@@ -25,10 +25,10 @@ export class IsBigIntIdStringConstraint implements ValidatorConstraintInterface 
  * @returns
  */
 export function IsBigIntIdString(validationOptions?: ValidationOptions) {
-  return (object: unknown, propertyName: string) => {
+  return (obj: object, propertyName: string) => {
     registerDecorator({
       name: 'isBigIntIdString',
-      target: object.constructor,
+      target: obj.constructor,
       propertyName: propertyName,
       options: validationOptions,
       validator: IsBigIntIdStringConstraint,

--- a/src/common/guards/is-owner.guard.ts
+++ b/src/common/guards/is-owner.guard.ts
@@ -11,11 +11,10 @@ export class IsOwnerGuard implements CanActivate {
     if (request.user === undefined) {
       return false;
     }
-
     // 403 Forbidden
     if (request.user.userId !== request.params?.userId) {
       throw new ForbiddenException('본인이 생성한 질문만 조회할 수 있습니다.');
     }
-    return false;
+    return true;
   }
 }

--- a/src/common/guards/is-owner.guard.ts
+++ b/src/common/guards/is-owner.guard.ts
@@ -8,7 +8,7 @@ export class IsOwnerGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean {
     const request: RequestUser = context.switchToHttp().getRequest();
-    if (request.user === undefined) {
+    if (!request.user?.userId) {
       return false;
     }
     // 403 Forbidden

--- a/src/common/guards/is-owner.guard.ts
+++ b/src/common/guards/is-owner.guard.ts
@@ -1,0 +1,21 @@
+import { RequestUser } from '@common/types/request-user.type';
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+@Injectable()
+export class IsOwnerGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request: RequestUser = context.switchToHttp().getRequest();
+    if (request.user === undefined) {
+      return false;
+    }
+
+    // 403 Forbidden
+    if (request.user.userId !== request.params?.userId) {
+      throw new ForbiddenException('본인이 생성한 질문만 조회할 수 있습니다.');
+    }
+    return false;
+  }
+}

--- a/src/common/types/request-user.type.ts
+++ b/src/common/types/request-user.type.ts
@@ -1,0 +1,4 @@
+import { User } from '@entities/user.entity';
+import { Request } from 'express';
+
+export type RequestUser = Request & { user: User };

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -37,7 +37,7 @@ export class AuthController {
   async googleLoginCallback(@Req() req: any, @Res() res: Response): Promise<void> {
     const { accessToken, userId } = await this.authService.googleLogin(req.user);
 
-    const redirectUrl = `${this.configService.get<string>('REDIRECT_URL')}/auth/callback?accessToken=${accessToken}&userId=${userId}`;
+    const redirectUrl = `${this.configService.get<string>('REDIRECT_URL')}/auth/callback?userId=${userId}&accessToken=${accessToken}`;
     res.redirect(redirectUrl);
   }
 }

--- a/src/modules/questions/dto/base-question.dto.ts
+++ b/src/modules/questions/dto/base-question.dto.ts
@@ -4,7 +4,7 @@ import { ApiProperty } from '@nestjs/swagger';
  * 공통 question 속성 정의
  * questionId, content, isHidden, createdAt
  */
-export class BaseQuestionDto implements Pick<BaseQuestionDto, 'questionId' | 'content' | 'isHidden' | 'createdAt'> {
+export class BaseQuestionDto {
   @ApiProperty({
     description: '질문 id',
     example: '1',

--- a/src/modules/questions/dto/base-question.dto.ts
+++ b/src/modules/questions/dto/base-question.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 공통 question 속성 정의
+ * questionId, content, isHidden, createdAt
+ */
+export class BaseQuestionDto implements Pick<BaseQuestionDto, 'questionId' | 'content' | 'isHidden' | 'createdAt'> {
+  @ApiProperty({
+    description: '질문 id',
+    example: '1',
+  })
+  questionId: string;
+
+  @ApiProperty({
+    description: '질문 내용',
+    example: '질문 내용',
+  })
+  content: string;
+
+  @ApiProperty({
+    description: '숨김 여부',
+    example: false,
+  })
+  isHidden: boolean;
+
+  @ApiProperty({
+    description: '생성일',
+    example: '2024-11-26T00:00:00',
+  })
+  createdAt: Date;
+}

--- a/src/modules/users/dto/get-my-questions.dto.ts
+++ b/src/modules/users/dto/get-my-questions.dto.ts
@@ -1,0 +1,3 @@
+import { BaseQuestionDto } from '@modules/questions/dto/base-question.dto';
+
+export type ResponseGetMyQuestionsDto = BaseQuestionDto[];

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,8 +1,11 @@
-import { GenerateSwaggerApiDoc } from '@common/common.decorator';
+import { GenerateSwaggerApiDoc, UserAuth } from '@common/common.decorator';
 import { BaseResponseDto } from '@common/common.dto';
+import { IsOwnerGuard } from '@common/guards/is-owner.guard';
 import { response } from '@common/helpers/common.helper';
 import { CheckBigIntIdPipe } from '@common/pipes/check-bigint-id.pipe';
-import { Controller, Get, Param } from '@nestjs/common';
+import { User } from '@entities/user.entity';
+import { BaseQuestionDto } from '@modules/questions/dto/base-question.dto';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { ResponseGetUserNicknameDto } from './dto/get-user-nickname.dto';
 import { UsersService } from './users.service';
@@ -11,6 +14,18 @@ import { UsersService } from './users.service';
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  @Get(':userId/questions')
+  @GenerateSwaggerApiDoc({
+    summary: '유저가 작성한 질문 조회',
+    description: '유저 id 기준 작성한 질문 조회, 로그인한 유저 id와 일치하지 않으면 조회 불가.',
+    responseType: [BaseQuestionDto],
+  })
+  @UseGuards(IsOwnerGuard)
+  async getMyQuestions(@Param('userId', CheckBigIntIdPipe) userId: string, @UserAuth() _loginUser: User) {
+    const questions = await this.usersService.getMyQuestions(userId);
+    return response(questions, '유저가 작성한 질문 조회 성공');
+  }
 
   @Get(':userId/nickname')
   @GenerateSwaggerApiDoc({

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -4,11 +4,12 @@ import { CustomTypeOrmModule } from '@common/custom-typeorm/custom-typeorm.modul
 import { LoggerModule } from '@logger/logger.module';
 import { UserRepository } from '@repositories/user.repository';
 
+import { QuestionRepository } from '@repositories/question.repository';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [CustomTypeOrmModule.forCustomRepository([UserRepository]), LoggerModule],
+  imports: [CustomTypeOrmModule.forCustomRepository([UserRepository, QuestionRepository]), LoggerModule],
   providers: [UsersService],
   controllers: [UsersController],
   exports: [UsersService],

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -4,12 +4,17 @@ import { GoogleUser } from '@common/types/google-user.type';
 import { User } from '@entities/user.entity';
 import { UserRepository } from '@repositories/user.repository';
 
+import { QuestionRepository } from '@repositories/question.repository';
+import { ResponseGetMyQuestionsDto } from './dto/get-my-questions.dto';
 import { ResponseGetUserNicknameDto } from './dto/get-user-nickname.dto';
 import { LoginType } from './users.constants';
 
 @Injectable()
 export class UsersService {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly questionRepository: QuestionRepository,
+  ) {}
 
   /**
    * 구글 사용자 로그인 혹은 회원가입
@@ -29,6 +34,17 @@ export class UsersService {
 
     const userId = await this.userRepository.createUser(googleUser.email, googleUser.displayName, LoginType.GOOGLE);
     return { userId, email: googleUser.email };
+  }
+
+  /**
+   * user 본인이 작성한 질문 조회
+   *
+   * @param userId
+   * @returns ResponseGetMyQuestionsDto: questionId, content, isHidden, createdAt의 배열
+   */
+  async getMyQuestions(userId: string): Promise<ResponseGetMyQuestionsDto> {
+    const questions = await this.questionRepository.findQuestionsByUserId(userId);
+    return questions;
   }
 
   /**

--- a/src/repositories/question.repository.ts
+++ b/src/repositories/question.repository.ts
@@ -35,6 +35,7 @@ export class QuestionRepository extends Repository<Question> {
     return this.find({
       select: ['questionId', 'content', 'isHidden', 'createdAt'],
       where: { userId },
+      order: { createdAt: 'DESC' },
     });
   }
 }

--- a/src/repositories/question.repository.ts
+++ b/src/repositories/question.repository.ts
@@ -29,4 +29,12 @@ export class QuestionRepository extends Repository<Question> {
   async findQuestionById(questionId: string): Promise<Question | null> {
     return this.findOne({ where: { questionId } });
   }
+
+  // NOTE: 최대 10개의 질문을 조회합니다.
+  async findQuestionsByUserId(userId: string): Promise<Question[]> {
+    return this.find({
+      select: ['questionId', 'content', 'isHidden', 'createdAt'],
+      where: { userId },
+    });
+  }
 }

--- a/test/questions.e2e-spec.ts
+++ b/test/questions.e2e-spec.ts
@@ -101,8 +101,10 @@ describe('Questions API test', () => {
         isHidden: false,
       };
 
+      const questionCount = await dataSource.getRepository('questions').count({ where: { userId: testUserId } });
+
       // 먼저 10개의 질문 생성
-      for (let i = 0; i < QUESTION_COUNT_LIMIT; i++) {
+      for (let i = 0; i < QUESTION_COUNT_LIMIT - questionCount; i++) {
         const response = await request(app.getHttpServer()).post('/questions').send(createQuestionDto).expect(201);
         createdQuestionIds.push(response.body.data.questionId);
       }

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -1,0 +1,98 @@
+import { Emotion } from '@entities/emotion.entity';
+import { Question } from '@entities/question.entity';
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import { createTestingApp } from './helpers/create-testing-app.helper';
+
+describe('Users API test', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  const loginUserId = '1'; // 테스트용 유저 ID
+  const targetUserId = '2'; // 테스트용 유저 ID
+  let targetQuestionIds: string[];
+  const hiddenQuestionContent = '숨김질문';
+  const insertQuestions = [
+    { userId: loginUserId, content: '질문1', isHidden: false },
+    { userId: loginUserId, content: '질문2', isHidden: false },
+    { userId: loginUserId, content: hiddenQuestionContent, isHidden: true },
+  ];
+
+  beforeAll(async () => {
+    const testApp = await createTestingApp();
+    app = testApp.app;
+    dataSource = testApp.dataSource;
+    await app.init();
+
+    const emotionRepository = dataSource.getRepository(Emotion);
+    const emotions = await emotionRepository.find();
+    if (emotions.length === 0) {
+      await emotionRepository.insert([
+        { emotionId: '1', name: '응원과 감사', emoji: '🌟' },
+        { emotionId: '2', name: '솔직한 대화', emoji: '🤝' },
+      ]);
+    }
+
+    const questionRepository = dataSource.getRepository(Question);
+    questionRepository.delete({ userId: loginUserId });
+
+    const result = await questionRepository.insert(insertQuestions);
+    targetQuestionIds = result.identifiers.map((item) => item.questionId);
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy(); // 데이터베이스 연결 종료
+    await app.close(); // 애플리케이션 종료
+  });
+
+  describe('GET /users/:userId/questions', () => {
+    it('유저가 작성한 질문 조회. 숨김여부 상관없이 모든 question 응답', () => {
+      return request(app.getHttpServer())
+        .get(`/users/${loginUserId}/questions`)
+        .expect(HttpStatus.OK)
+        .expect((response) => {
+          const { body } = response;
+          expect(response.body).toHaveProperty('data');
+          expect(response.body).toHaveProperty('message');
+          expect(response.body).toHaveProperty('status');
+
+          expect(body.data).toBeInstanceOf(Array);
+          expect(body.data.length).toBe(3);
+
+          for (const q of body.data) {
+            expect(q).toHaveProperty('questionId');
+            expect(q).toHaveProperty('content');
+            expect(q).toHaveProperty('isHidden');
+            expect(q).toHaveProperty('createdAt');
+          }
+        });
+    });
+
+    it('유저가 작성한 질문이 없을 때 data에 빈 배열 응답', () => {
+      dataSource.getRepository(Question).delete({ userId: loginUserId });
+
+      const res = request(app.getHttpServer())
+        .get(`/users/${loginUserId}/questions`)
+        .expect(HttpStatus.OK)
+        .expect((response) => {
+          const { body } = response;
+          expect(response.body).toHaveProperty('data');
+          expect(response.body).toHaveProperty('message');
+          expect(response.body).toHaveProperty('status');
+
+          expect(body.data).toBeInstanceOf(Array);
+          expect(body.data.length).toBe(0);
+        });
+
+      dataSource.getRepository(Question).insert(insertQuestions);
+      return res;
+    });
+
+    it('로그인한 유저와 조회 대상 유저가 다를 때 403 에러', () => {
+      return request(app.getHttpServer())
+        .get(`/users/${targetUserId}/questions`)
+        .set('userId', loginUserId)
+        .expect(HttpStatus.FORBIDDEN);
+    });
+  });
+});

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -34,7 +34,7 @@ describe('Users API test', () => {
     }
 
     const questionRepository = dataSource.getRepository(Question);
-    questionRepository.delete({ userId: loginUserId });
+    await questionRepository.delete({ userId: loginUserId });
 
     const result = await questionRepository.insert(insertQuestions);
     targetQuestionIds = result.identifiers.map((item) => item.questionId);
@@ -68,10 +68,13 @@ describe('Users API test', () => {
         });
     });
 
-    it('유저가 작성한 질문이 없을 때 data에 빈 배열 응답', () => {
-      dataSource.getRepository(Question).delete({ userId: loginUserId });
+    it('유저가 작성한 질문이 없을 때 data에 빈 배열 응답', async () => {
+      await dataSource.getRepository(Question).delete({ userId: loginUserId });
 
-      const res = request(app.getHttpServer())
+      const questionsAfterDelete = await dataSource.getRepository(Question).find({ where: { userId: loginUserId } });
+      expect(questionsAfterDelete.length).toBe(0); // 데이터 삭제 확인
+
+      const res = await request(app.getHttpServer())
         .get(`/users/${loginUserId}/questions`)
         .expect(HttpStatus.OK)
         .expect((response) => {
@@ -84,7 +87,7 @@ describe('Users API test', () => {
           expect(body.data.length).toBe(0);
         });
 
-      dataSource.getRepository(Question).insert(insertQuestions);
+      await dataSource.getRepository(Question).insert(insertQuestions);
       return res;
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": true,
     "strictFunctionTypes": true,
+    "strictNullChecks": true,
     "useUnknownInCatchVariables": false,
     "allowUnreachableCode": false,
     "paths": {


### PR DESCRIPTION
## Summary
- 내가 작성한 질문리스트를 가져오는 `GET /users/:userId/questions` API 구현
- 로그인한 유저와 path parameter로 온 userId가 같은지 확인하는 `IsOwnerGuard` 구현

## Describe your changes
- `GET /users/:userId/questions`
  - 로그인한 유저의 모든 질문을 가져오는 question service 함수 `getMyQuestions`구현
  - 10개까지 생성 가능하므로 pagination 없이 단순 list GET
  - 추후 question 관련 로직에서 공통으로 사용할 `BaseQuestionDto` 정의
- `IsOwnerGuard` 
  - `jwtGuard`에서 설정해주는 `Request.user`와 path parameter의 `userId`를 비교
  - express의 `Request`에 `user: User` property 를 append한 `RequestUser` 타입 정의
- `GenerateSwaggerApiDoc`
  - data에 배열을 제공하는 `GET /users/:userId/questions` API를 구현하면서 기존: `Type<unknown>`에만 대응되었던 `GenerateSwaggerApiDoc` decrator를 배열 타입도 대응할 수 있도록 변경.
- etc
  - 구글 로그인 후 client로 redirection 해주는 url의 query string 순서를 accessToken, userId에서 userId, accessToken으로 변경
    - swagger로 토큰 넣어서 테스트 할 때 불편해서.. 잘 복사하기 위해서 변경했습니다.

## Issue number and link
- close #24 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 소유 질문을 검색하는 새로운 API 엔드포인트 추가.
	- 질문의 기본 속성을 정의하는 `BaseQuestionDto` 클래스 추가.
	- 사용자 질문을 가져오는 `getMyQuestions` 메소드 추가.
	- `IsOwnerGuard` 클래스를 추가하여 자원 소유 기반 접근 제어 구현.
	- 질문과 관련된 기능을 통합하여 `UsersService` 확장.

- **버그 수정**
	- `ResponseDtoType` 함수와 `SwaggerDocInterface`의 타입 유연성 향상.
	- `IsBigIntIdString` 데코레이터의 매개변수 이름 수정.

- **테스트**
	- 사용자 질문 검색을 위한 새로운 E2E 테스트 스위트 추가.
	- 질문 생성 한도 처리를 위한 테스트 로직 개선.

- **문서화**
	- Swagger 문서화에 필요한 메타데이터 추가.
	- `strictNullChecks` 옵션을 추가하여 타입 안전성 향상.

- **기타**
	- PostgreSQL 서비스 및 볼륨 구성 수정.
	- `test:e2e` 스크립트 수정으로 E2E 테스트 실행 방식 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->