### PR TITLE
✨ [Feature] 쪽지 상세정보 조회 API

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -46,7 +46,8 @@
         "useImportType": "off",
         "noArguments": "error",
         "noVar": "error",
-        "useConst": "error"
+        "useConst": "error",
+        "noInferrableTypes": "off"
       },
       "suspicious": {
         "noExplicitAny": "off",

--- a/database/init-scripts/init.sql
+++ b/database/init-scripts/init.sql
@@ -145,11 +145,24 @@ COMMENT ON TABLE message_statistics IS '전체 쪽지, 안읽은 쪽지의 개�
 
 -- Emotions table
 CREATE TABLE emotions (
+    emotion_id integer NOT NULL DEFAULT nextval('emotions_emotion_id_seq'::regclass),
     name character varying(50) NOT NULL,
     emoji character varying(10) NOT NULL,
-    emotion_id integer NOT NULL DEFAULT nextval('emotions_emotion_id_seq'::regclass),
     CONSTRAINT emotions_pkey PRIMARY KEY (emotion_id)
 );
+
+-- Reaction info table
+CREATE TABLE reaction_info (
+		message_id bigint NOT NULL,
+		read_at timestamp(6),
+		created_at timestamp(6) NOT NULL,
+		CONSTRAINT reaction_info_pkey PRIMARY KEY (message_id),
+		CONSTRAINT reaction_info_message_id_uq UNIQUE (message_id)
+);
+
+COMMENT ON TABLE keepintouch_dev.reaction_info IS E'reaction 생성, 읽음 일자';
+
+
 
 -- Foreign key constraints
 ALTER TABLE questions
@@ -192,6 +205,10 @@ ALTER TABLE message_statistics
     FOREIGN KEY (user_id) REFERENCES users(user_id)
     ON DELETE CASCADE;
 
+ALTER TABLE reaction_info
+		ADD CONSTRAINT reaction_info_message_id_fkey
+		FOREIGN KEY (message_id) REFERENCES messages (message_id)
+	  ON DELETE CASCADE;
 
 -- Insert data into reaction_templates
 INSERT INTO reaction_templates (emoji, type, content)

--- a/src/common/helpers/pagination-option.helper.ts
+++ b/src/common/helpers/pagination-option.helper.ts
@@ -1,0 +1,12 @@
+import { OrderOption } from '@common/types/pagination-option.type';
+
+export function getOrderUpperCase(order: string): OrderOption {
+  switch (order) {
+    case 'asc':
+      return 'ASC';
+    case 'desc':
+      return 'DESC';
+    default:
+      return 'DESC';
+  }
+}

--- a/src/common/types/pagination-option.type.ts
+++ b/src/common/types/pagination-option.type.ts
@@ -1,0 +1,7 @@
+export type OrderOption = 'ASC' | 'DESC';
+
+export type PaginationOption = {
+  cursor?: Date;
+  limit: number;
+  order: OrderOption;
+};

--- a/src/entities/message.entity.ts
+++ b/src/entities/message.entity.ts
@@ -8,11 +8,13 @@ import {
   JoinColumn,
   ManyToOne,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { Emotion } from './emotion.entity';
 import { Question } from './question.entity';
+import { ReactionInfo } from './reaction-info.entity';
 import { Reaction } from './reaction.entity';
 import { User } from './user.entity';
 
@@ -97,4 +99,11 @@ export class Message {
     (reaction) => reaction.message,
   )
   reactions: Reaction[];
+
+  @OneToOne(
+    () => ReactionInfo,
+    (reactionInfo) => reactionInfo.message,
+  )
+  @JoinColumn({ name: 'message_id' })
+  reactionInfo: ReactionInfo;
 }

--- a/src/entities/reaction-info.entity.ts
+++ b/src/entities/reaction-info.entity.ts
@@ -1,0 +1,21 @@
+import { Column, CreateDateColumn, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
+import { Message } from './message.entity';
+
+@Entity({ name: 'reaction_info' })
+export class ReactionInfo {
+  @PrimaryColumn({ name: 'message_id', type: 'bigint' })
+  @JoinColumn({ name: 'message_id' })
+  messageId: string;
+
+  @OneToOne(
+    () => Message,
+    (message) => message.reactionInfo,
+  )
+  message: Message;
+
+  @Column({ name: 'read_at', type: 'timestamp', nullable: true })
+  readAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp' })
+  createdAt: Date;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,9 +9,12 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
+  process.env.TZ = 'UTC'; // FIXME: 서버시간을 강제로 UTC로 설정
+  // 이유: KST 인 호스트에서 실행되면 timestamp without timezone으로 저장된 모든 데이터가 실제보다 9시간 빠르게 조회됨
+  // pagination 등에서 엄청난 데이터 불일치가 발생함.
+  // 서버를 UTC로 설정해서 해결 가능.
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);
-
   const logger = app.get(CustomLogger);
   app.useLogger(logger);
   // 환경 변수 로드

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,6 @@ async function bootstrap() {
     .setTitle(`${configService.get('APP_NAME')}_${configService.get('APP_ENV')}`)
     .setDescription('API description')
     .setVersion('2.0')
-    // .addTag('your-tag')
     .addBearerAuth(
       {
         type: 'http',

--- a/src/modules/messages/dto/get-my-messages.dto.ts
+++ b/src/modules/messages/dto/get-my-messages.dto.ts
@@ -1,7 +1,0 @@
-import { BaseMessageDto } from './base-message.dto';
-
-export class GetMyMessagesDto {
-  sentMessageCount: number;
-  nextCursor: Date | null;
-  messageList: BaseMessageDto[];
-}

--- a/src/modules/messages/dto/message-detail.dto.ts
+++ b/src/modules/messages/dto/message-detail.dto.ts
@@ -85,7 +85,7 @@ export class ReceivedMessageDetailDto extends MessageDetailDto {
     const status = getMessageStatusString(message.status);
     return {
       ...base,
-      type: 'received',
+      type: MessageType.RECEIVED,
       status,
     };
   }
@@ -96,7 +96,7 @@ export class SentMessageDetailDto extends MessageDetailDto {
     const base = MessageDetailDto.baseFrom(message);
     return {
       ...base,
-      type: 'sent',
+      type: MessageType.SENT,
     };
   }
 }

--- a/src/modules/messages/dto/message-detail.dto.ts
+++ b/src/modules/messages/dto/message-detail.dto.ts
@@ -85,7 +85,7 @@ export class ReceivedMessageDetailDto extends MessageDetailDto {
     const status = getMessageStatusString(message.status);
     return {
       ...base,
-      type: MessageType.RECEIVED,
+      type: 'received',
       status,
     };
   }
@@ -96,7 +96,7 @@ export class SentMessageDetailDto extends MessageDetailDto {
     const base = MessageDetailDto.baseFrom(message);
     return {
       ...base,
-      type: MessageType.SENT,
+      type: 'sent',
     };
   }
 }

--- a/src/modules/messages/messages.service.spec.ts
+++ b/src/modules/messages/messages.service.spec.ts
@@ -27,6 +27,9 @@ describe('MessagesService', () => {
             createQuestionMessage: jest.fn(),
             createEmotionMessage: jest.fn(),
             findMessageDetailById: jest.fn(),
+            manager: {
+              transaction: jest.fn(),
+            },
           },
         },
         {
@@ -297,7 +300,7 @@ describe('MessagesService', () => {
       status: MessageStatus.NORMAL,
     };
 
-    jest.spyOn(messageRepository, 'findMessageDetailById').mockResolvedValue(message as Message);
+    jest.spyOn(messageRepository, 'findMessageDetailById').mockResolvedValue(message as any);
 
     await expect(service.getMessageDetail(messageDetailParam)).rejects.toThrow(ForbiddenException);
   });

--- a/src/modules/messages/messages.service.ts
+++ b/src/modules/messages/messages.service.ts
@@ -61,21 +61,20 @@ export class MessagesService {
     userId,
     messageId,
   }: MessageDetailParam): Promise<SentMessageDetailDto | ReceivedMessageDetailDto> {
-    const message = await this.messageRepository.findMessageDetailById(messageId);
+    const message = await this.messageRepository.findMessageDetailById(messageId, userId);
 
     if (!message) {
       throw new NotFoundException('쪽지가 존재하지 않습니다.');
     }
-    let dto: SentMessageDetailDto | ReceivedMessageDetailDto;
-
-    if (message.senderId === userId) {
-      dto = SentMessageDetailDto.from(message);
-    } else if (message.receiverId === userId) {
-      dto = ReceivedMessageDetailDto.from(message);
-    } else {
+    if (message.senderId !== userId && message.receiverId !== userId) {
       throw new ForbiddenException('쪽지를 볼 권한이 없습니다.');
     }
-    return dto;
+
+    // DTO 변환
+    if (message.senderId === userId) {
+      return SentMessageDetailDto.from(message);
+    }
+    return ReceivedMessageDetailDto.from(message);
   }
 
   /**

--- a/src/modules/messages/types/messages.type.ts
+++ b/src/modules/messages/types/messages.type.ts
@@ -16,15 +16,9 @@ export type CreateEmotionMessageParam = MessageBaseData & {
   questionId?: never;
 };
 
-export enum MessageType {
-  RECEIVED = 'received',
-  SENT = 'sent',
-}
+export type MessageType = 'received' | 'sent';
 
-export enum MessageOrder {
-  DESC = 'desc',
-  ASC = 'asc',
-}
+export type MessageOrder = 'desc' | 'asc';
 
 export type MessageStatusString = 'normal' | 'hidden' | 'reported';
 

--- a/src/modules/messages/types/messages.type.ts
+++ b/src/modules/messages/types/messages.type.ts
@@ -16,7 +16,15 @@ export type CreateEmotionMessageParam = MessageBaseData & {
   questionId?: never;
 };
 
-export type MessageType = 'sent' | 'received';
+export enum MessageType {
+  RECEIVED = 'received',
+  SENT = 'sent',
+}
+
+export enum MessageOrder {
+  DESC = 'desc',
+  ASC = 'asc',
+}
 
 export type MessageStatusString = 'normal' | 'hidden' | 'reported';
 

--- a/src/modules/users/dto/get-my-messages.dto.ts
+++ b/src/modules/users/dto/get-my-messages.dto.ts
@@ -3,7 +3,7 @@ import { getMessageStatusString } from '@modules/messages/helpers/message-reacti
 import { MessageOrder, MessageStatusString, MessageType } from '@modules/messages/types/messages.type';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsDateString, IsEnum, IsIn, IsOptional, Max, Min } from 'class-validator';
+import { IsDateString, IsIn, IsOptional, Max, Min } from 'class-validator';
 import { BaseMessageDto } from '../../messages/dto/base-message.dto';
 
 /**
@@ -15,10 +15,9 @@ import { BaseMessageDto } from '../../messages/dto/base-message.dto';
 export class GetMyMessagesQuery {
   @ApiProperty({
     description: '받은 쪽지, 보낸 쪽지 구분 (received/sent)',
-    example: MessageType.RECEIVED,
-    enum: MessageType,
+    example: 'received',
   })
-  @IsEnum(MessageType)
+  @IsIn(['received', 'sent'])
   type: MessageType; // received/sent
 
   // IsDate?
@@ -49,7 +48,7 @@ export class GetMyMessagesQuery {
   })
   @IsOptional()
   @IsIn(['desc', 'asc'])
-  order: MessageOrder = MessageOrder.DESC;
+  order: MessageOrder = 'desc';
 }
 
 // message type
@@ -104,7 +103,10 @@ export class SentMessageDto extends BaseMessageDto {
       receiverNickname: message.receiver.nickname,
       content: message.content,
       createdAt: message.createdAt,
-      reactionInfo: message.reactionInfo,
+      reactionInfo: message.reactionInfo && {
+        createdAt: message.reactionInfo.createdAt,
+        readAt: message.reactionInfo.readAt,
+      },
     };
   }
 }

--- a/src/modules/users/dto/get-my-messages.dto.ts
+++ b/src/modules/users/dto/get-my-messages.dto.ts
@@ -112,6 +112,27 @@ export class SentMessageDto extends BaseMessageDto {
 }
 
 export class GetMySentMessagesDto {
+  @ApiProperty({
+    description: '유저가 보낸 총 메세지 개수',
+    example: 30,
+  })
+  sentMessageCount: number;
+
+  @ApiProperty({
+    description: '다음 페이지 cursor, 없을 경우 null',
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+    example: '2024-11-29T16:03:19.378Z',
+  })
+  nextCursor: Date | null;
+
+  @ApiProperty({
+    description: '유저가 보낸 메세지 리스트',
+    type: [SentMessageDto],
+  })
+  messageList: SentMessageDto[];
+
   static from(messages: Message[], meta: { sentMessageCount: number; nextCursor: Date | null }) {
     return {
       sentMessageCount: meta.sentMessageCount,
@@ -122,6 +143,28 @@ export class GetMySentMessagesDto {
 }
 
 export class GetMyReceivedMessagedDto {
+  @ApiProperty({
+    description: '유저가 받은 총 메세지 개수',
+    example: 30,
+  })
+  receivedMessageCount: number;
+
+  @ApiProperty({
+    description: '유저가 받은 읽지 않은 메세지 개수',
+    example: 3,
+  })
+  unreadMessageCount: number;
+
+  @ApiProperty({
+    description: '다음 페이지 cursor, 없을 경우 null',
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+    example: '2024-11-29T16:03:19.378Z',
+  })
+  nextCursor: Date | null;
+  messageList: ReceivedMessageDto[];
+
   static from(
     messages: Message[],
     meta: { receivedMessageCount: number; unreadMessageCount: number; nextCursor: Date | null },

--- a/src/modules/users/dto/get-my-messages.dto.ts
+++ b/src/modules/users/dto/get-my-messages.dto.ts
@@ -1,0 +1,136 @@
+import { Message } from '@entities/message.entity';
+import { getMessageStatusString } from '@modules/messages/helpers/message-reaction.helper';
+import { MessageOrder, MessageStatusString, MessageType } from '@modules/messages/types/messages.type';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsDateString, IsEnum, IsIn, IsOptional, Max, Min } from 'class-validator';
+import { BaseMessageDto } from '../../messages/dto/base-message.dto';
+
+/**
+ * type	받은 쪽지, 보낸 쪽지 구분 (received/sent)
+ * cursor(datetime)	가장 최근 일자 (datetime)
+ * limit	가져올 쪽지 개수 (default: 10)
+ * order	정렬 (desc/asc), (default: desc)
+ */
+export class GetMyMessagesQuery {
+  @ApiProperty({
+    description: '받은 쪽지, 보낸 쪽지 구분 (received/sent)',
+    example: MessageType.RECEIVED,
+    enum: MessageType,
+  })
+  @IsEnum(MessageType)
+  type: MessageType; // received/sent
+
+  // IsDate?
+  @ApiProperty({
+    description: '가져올 가장 최근 메세지의 일자 (default: 현재 시점 datetime)',
+    required: false,
+    example: '2024-11-29T16:03:19.378Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  cursor?: Date;
+
+  @ApiProperty({
+    description: '가져올 쪽지 개수 (default: 3)',
+    required: false,
+    example: 3,
+  })
+  @IsOptional()
+  @Min(1)
+  @Max(30)
+  @Type(() => Number) // number로 변환해주어야 최대, 최소값 검사 가능
+  limit: number = 3;
+
+  @ApiProperty({
+    description: '정렬 (desc/asc), (default: desc)',
+    required: false,
+    example: 'desc',
+  })
+  @IsOptional()
+  @IsIn(['desc', 'asc'])
+  order: MessageOrder = MessageOrder.DESC;
+}
+
+// message type
+export class ReceivedMessageDto extends BaseMessageDto {
+  @ApiProperty({
+    description: '메세지 상태: 정상, 숨김처리, 신고됨',
+    example: 'normal',
+  })
+  status: MessageStatusString;
+
+  @ApiProperty({
+    description: '내가 읽은 메세지 날짜',
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+    example: '2024-11-29T16:03:19.378Z',
+  })
+  readAt: Date | null; // 메세지 (내가) 읽은 날짜
+
+  static from(message: Message): ReceivedMessageDto {
+    return {
+      messageId: message.messageId,
+      receiverId: message.receiver.userId,
+      receiverNickname: message.receiver.nickname,
+      content: message.content,
+      createdAt: message.createdAt,
+      status: getMessageStatusString(message.status),
+      readAt: message.readAt,
+    };
+  }
+}
+
+export class SentMessageDto extends BaseMessageDto {
+  @ApiProperty({
+    description: 'reaction 생성 날짜, 읽음 날짜. reaction이 없을 경우 null',
+    type: 'object',
+    nullable: true,
+    properties: {
+      createdAt: { type: 'string', format: 'date-time', nullable: true },
+      readAt: { type: 'string', format: 'date-time', nullable: true },
+    },
+  })
+  reactionInfo: {
+    createdAt: Date | null;
+    readAt: Date | null;
+  } | null;
+
+  static from(message: Message): SentMessageDto {
+    return {
+      messageId: message.messageId,
+      receiverId: message.receiver.userId,
+      receiverNickname: message.receiver.nickname,
+      content: message.content,
+      createdAt: message.createdAt,
+      reactionInfo: message.reactionInfo,
+    };
+  }
+}
+
+export class GetMySentMessagesDto {
+  static from(messages: Message[], meta: { sentMessageCount: number; nextCursor: Date | null }) {
+    return {
+      sentMessageCount: meta.sentMessageCount,
+      nextCursor: meta.nextCursor,
+      messageList: messages.map(SentMessageDto.from),
+    };
+  }
+}
+
+export class GetMyReceivedMessagedDto {
+  static from(
+    messages: Message[],
+    meta: { receivedMessageCount: number; unreadMessageCount: number; nextCursor: Date | null },
+  ) {
+    return {
+      receivedMessageCount: meta.receivedMessageCount,
+      unreadMessageCount: meta.unreadMessageCount,
+      nextCursor: meta.nextCursor,
+      messageList: messages.map(ReceivedMessageDto.from),
+    };
+  }
+}
+
+export type GetMyMessagesResponseDto = GetMyReceivedMessagedDto | GetMySentMessagesDto;

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -6,7 +6,7 @@ import { CheckBigIntIdPipe } from '@common/pipes/check-bigint-id.pipe';
 import { BaseQuestionDto } from '@modules/questions/dto/base-question.dto';
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { GetMyMessagesQuery } from './dto/get-my-messages.dto';
+import { GetMyMessagesQuery, GetMySentMessagesDto } from './dto/get-my-messages.dto';
 import { ResponseGetUserNicknameDto } from './dto/get-user-nickname.dto';
 import { UsersService } from './users.service';
 
@@ -31,6 +31,7 @@ export class UsersController {
   @GenerateSwaggerApiDoc({
     summary: '유저가 작성한 쪽지 조회',
     description: '유저 id 기준 작성한 쪽지 조회, 로그인한 유저 id와 일치하지 않으면 조회 불가. ',
+    responseType: GetMySentMessagesDto,
   })
   @UseGuards(IsOwnerGuard)
   async getMyMessages(@Param('userId', CheckBigIntIdPipe) userId: string, @Query() query: GetMyMessagesQuery) {

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,12 +1,12 @@
-import { GenerateSwaggerApiDoc, UserAuth } from '@common/common.decorator';
+import { GenerateSwaggerApiDoc } from '@common/common.decorator';
 import { BaseResponseDto } from '@common/common.dto';
 import { IsOwnerGuard } from '@common/guards/is-owner.guard';
 import { response } from '@common/helpers/common.helper';
 import { CheckBigIntIdPipe } from '@common/pipes/check-bigint-id.pipe';
-import { User } from '@entities/user.entity';
 import { BaseQuestionDto } from '@modules/questions/dto/base-question.dto';
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { GetMyMessagesQuery } from './dto/get-my-messages.dto';
 import { ResponseGetUserNicknameDto } from './dto/get-user-nickname.dto';
 import { UsersService } from './users.service';
 
@@ -22,9 +22,20 @@ export class UsersController {
     responseType: [BaseQuestionDto],
   })
   @UseGuards(IsOwnerGuard)
-  async getMyQuestions(@Param('userId', CheckBigIntIdPipe) userId: string, @UserAuth() _loginUser: User) {
+  async getMyQuestions(@Param('userId', CheckBigIntIdPipe) userId: string) {
     const questions = await this.usersService.getMyQuestions(userId);
     return response(questions, '유저가 작성한 질문 조회 성공');
+  }
+
+  @Get(':userId/messages')
+  @GenerateSwaggerApiDoc({
+    summary: '유저가 작성한 쪽지 조회',
+    description: '유저 id 기준 작성한 쪽지 조회, 로그인한 유저 id와 일치하지 않으면 조회 불가. ',
+  })
+  @UseGuards(IsOwnerGuard)
+  async getMyMessages(@Param('userId', CheckBigIntIdPipe) userId: string, @Query() query: GetMyMessagesQuery) {
+    const messages = await this.usersService.getMyMessages(userId, query);
+    return response(messages, '유저 쪽지 조회 성공');
   }
 
   @Get(':userId/nickname')

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -4,12 +4,22 @@ import { CustomTypeOrmModule } from '@common/custom-typeorm/custom-typeorm.modul
 import { LoggerModule } from '@logger/logger.module';
 import { UserRepository } from '@repositories/user.repository';
 
+import { MessageStatisticRepository } from '@repositories/message-statistic.repository';
+import { MessageRepository } from '@repositories/message.repository';
 import { QuestionRepository } from '@repositories/question.repository';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [CustomTypeOrmModule.forCustomRepository([UserRepository, QuestionRepository]), LoggerModule],
+  imports: [
+    CustomTypeOrmModule.forCustomRepository([
+      UserRepository,
+      QuestionRepository,
+      MessageRepository,
+      MessageStatisticRepository,
+    ]),
+    LoggerModule,
+  ],
   providers: [UsersService],
   controllers: [UsersController],
   exports: [UsersService],

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -4,7 +4,8 @@ import { GoogleUser } from '@common/types/google-user.type';
 import { User } from '@entities/user.entity';
 import { UserRepository } from '@repositories/user.repository';
 
-import { OrderOption, PaginationOption } from '@common/types/pagination-option.type';
+import { getOrderUpperCase } from '@common/helpers/pagination-option.helper';
+import { PaginationOption } from '@common/types/pagination-option.type';
 import { Message } from '@entities/message.entity';
 //import { MessageStatisticRepository } from '@repositories/message-statistic.repository';
 import { MessageRepository } from '@repositories/message.repository';
@@ -65,7 +66,7 @@ export class UsersService {
     const paginationOptions: PaginationOption = {
       cursor: query.cursor,
       limit: query.limit,
-      order: query.order.toUpperCase() as OrderOption,
+      order: getOrderUpperCase(query.order),
     };
 
     const messages = await this.messageRepository.findMessagesByUserId(userId, type, paginationOptions);
@@ -135,7 +136,7 @@ export class UsersService {
   private async getReceivedMetaData(userId: string, messages: Message[]) {
     // NOTE: message 테이블을 가져와 세는 방식으로 변경.
     const allMessage = await this.messageRepository.find({
-      select: ['readAt'],
+      select: ['readAt', 'messageId'], // NOTE: readAt만 select하면 typeorm이 null인 값은 거른다... (대체왜ㅠㅠ)
       where: { receiverId: userId },
     });
     const receivedMessageCount = allMessage.length;

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -6,7 +6,7 @@ import { UserRepository } from '@repositories/user.repository';
 
 import { OrderOption, PaginationOption } from '@common/types/pagination-option.type';
 import { Message } from '@entities/message.entity';
-import { MessageStatisticRepository } from '@repositories/message-statistic.repository';
+//import { MessageStatisticRepository } from '@repositories/message-statistic.repository';
 import { MessageRepository } from '@repositories/message.repository';
 import { QuestionRepository } from '@repositories/question.repository';
 import {
@@ -25,7 +25,7 @@ export class UsersService {
     private readonly userRepository: UserRepository,
     private readonly questionRepository: QuestionRepository,
     private readonly messageRepository: MessageRepository,
-    private readonly messageStatisticRepository: MessageStatisticRepository,
+    //private readonly messageStatisticRepository: MessageStatisticRepository,
   ) {}
 
   /**
@@ -121,20 +121,30 @@ export class UsersService {
   }
 
   private async getSentMetaData(userId: string, messages: Message[]) {
-    // TODO: reaction info get
-    const { sentMessageCount } = await this.messageStatisticRepository.findOneOrFail({
-      select: ['sentMessageCount'],
-      where: { userId: userId },
-    });
+    //// TODO: reaction info get
+    //const { sentMessageCount } = await this.messageStatisticRepository.findOneOrFail({
+    //  select: ['sentMessageCount'],
+    //  where: { userId: userId },
+    //});
+
+    const sentMessageCount = await this.messageRepository.countBy({ senderId: userId });
     const nextCursor = messages.length > 0 ? messages[messages.length - 1].createdAt : null;
     return { sentMessageCount, nextCursor };
   }
 
   private async getReceivedMetaData(userId: string, messages: Message[]) {
-    const { receivedMessageCount, unreadMessageCount } = await this.messageStatisticRepository.findOneOrFail({
-      select: ['receivedMessageCount', 'unreadMessageCount'],
-      where: { userId: userId },
+    // NOTE: message 테이블을 가져와 세는 방식으로 변경.
+    const allMessage = await this.messageRepository.find({
+      select: ['readAt'],
+      where: { receiverId: userId },
     });
+    const receivedMessageCount = allMessage.length;
+    const unreadMessageCount = allMessage.filter((message) => message.readAt === null).length;
+
+    //const { receivedMessageCount, unreadMessageCount } = await this.messageStatisticRepository.findOneOrFail({
+    //  select: ['receivedMessageCount', 'unreadMessageCount'],
+    //  where: { userId: userId },
+    //});
     const nextCursor = messages.length > 0 ? messages[messages.length - 1].createdAt : null;
     return { receivedMessageCount, unreadMessageCount, nextCursor };
   }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -4,7 +4,17 @@ import { GoogleUser } from '@common/types/google-user.type';
 import { User } from '@entities/user.entity';
 import { UserRepository } from '@repositories/user.repository';
 
+import { OrderOption, PaginationOption } from '@common/types/pagination-option.type';
+import { Message } from '@entities/message.entity';
+import { MessageStatisticRepository } from '@repositories/message-statistic.repository';
+import { MessageRepository } from '@repositories/message.repository';
 import { QuestionRepository } from '@repositories/question.repository';
+import {
+  GetMyMessagesQuery,
+  GetMyMessagesResponseDto,
+  GetMyReceivedMessagedDto,
+  GetMySentMessagesDto,
+} from './dto/get-my-messages.dto';
 import { ResponseGetMyQuestionsDto } from './dto/get-my-questions.dto';
 import { ResponseGetUserNicknameDto } from './dto/get-user-nickname.dto';
 import { LoginType } from './users.constants';
@@ -14,6 +24,8 @@ export class UsersService {
   constructor(
     private readonly userRepository: UserRepository,
     private readonly questionRepository: QuestionRepository,
+    private readonly messageRepository: MessageRepository,
+    private readonly messageStatisticRepository: MessageStatisticRepository,
   ) {}
 
   /**
@@ -46,6 +58,25 @@ export class UsersService {
   async getMyQuestions(userId: string): Promise<ResponseGetMyQuestionsDto> {
     const questions = await this.questionRepository.findQuestionsByUserId(userId);
     return questions;
+  }
+
+  async getMyMessages(userId: string, query: GetMyMessagesQuery): Promise<GetMyMessagesResponseDto> {
+    const { type } = query;
+    const paginationOptions: PaginationOption = {
+      cursor: query.cursor,
+      limit: query.limit,
+      order: query.order.toUpperCase() as OrderOption,
+    };
+
+    const messages = await this.messageRepository.findMessagesByUserId(userId, type, paginationOptions);
+
+    if (type === 'sent') {
+      const meta = await this.getSentMetaData(userId, messages);
+      return GetMySentMessagesDto.from(messages, meta);
+    }
+
+    const meta = await this.getReceivedMetaData(userId, messages);
+    return GetMyReceivedMessagedDto.from(messages, meta);
   }
 
   /**
@@ -87,5 +118,24 @@ export class UsersService {
     const maxNumber = 9999;
     const randomNumber = Math.floor(Math.random() * (maxNumber - minNumber + 1)) + minNumber;
     return `퐁${randomNumber}`;
+  }
+
+  private async getSentMetaData(userId: string, messages: Message[]) {
+    // TODO: reaction info get
+    const { sentMessageCount } = await this.messageStatisticRepository.findOneOrFail({
+      select: ['sentMessageCount'],
+      where: { userId: userId },
+    });
+    const nextCursor = messages.length > 0 ? messages[messages.length - 1].createdAt : null;
+    return { sentMessageCount, nextCursor };
+  }
+
+  private async getReceivedMetaData(userId: string, messages: Message[]) {
+    const { receivedMessageCount, unreadMessageCount } = await this.messageStatisticRepository.findOneOrFail({
+      select: ['receivedMessageCount', 'unreadMessageCount'],
+      where: { userId: userId },
+    });
+    const nextCursor = messages.length > 0 ? messages[messages.length - 1].createdAt : null;
+    return { receivedMessageCount, unreadMessageCount, nextCursor };
   }
 }

--- a/test/helpers/create-testing-app.helper.ts
+++ b/test/helpers/create-testing-app.helper.ts
@@ -1,7 +1,6 @@
 import { AllExceptionsFilter } from '@common/filters/all-exception.filter';
 import { JwtAuthGuard } from '@common/guards/jwt-auth.guard';
 import { LoggingInterceptor } from '@common/interceptors/logging.interceptor';
-import { MessageStatistic } from '@entities/message-statistic.entity';
 import { User } from '@entities/user.entity';
 import { CustomLogger } from '@logger/custom-logger.service';
 import { ExecutionContext, INestApplication, ValidationPipe } from '@nestjs/common';
@@ -84,26 +83,26 @@ export const createTestingApp = async (
       await manager.insert(User, targetUser);
     }
 
-    await manager.upsert(
-      MessageStatistic,
-      [
-        {
-          userId: loginUser.userId,
-          receivedMessageCount: 0,
-          sentMessageCount: 0,
-          unreadMessageCount: 0,
-          unreadReactionCount: 0,
-        },
-        {
-          userId: targetUser.userId,
-          receivedMessageCount: 0,
-          sentMessageCount: 0,
-          unreadMessageCount: 0,
-          unreadReactionCount: 0,
-        },
-      ],
-      ['userId'],
-    );
+    //await manager.upsert(
+    //  MessageStatistic,
+    //  [
+    //    {
+    //      userId: loginUser.userId,
+    //      receivedMessageCount: 0,
+    //      sentMessageCount: 0,
+    //      unreadMessageCount: 0,
+    //      unreadReactionCount: 0,
+    //    },
+    //    {
+    //      userId: targetUser.userId,
+    //      receivedMessageCount: 0,
+    //      sentMessageCount: 0,
+    //      unreadMessageCount: 0,
+    //      unreadReactionCount: 0,
+    //    },
+    //  ],
+    //  ['userId'],
+    //);
   });
 
   return { app, dataSource };


### PR DESCRIPTION
## Summary
- `GET /users/:userId/messages` API 구현
- message detail api 에 read 하는 부분 없었던 문제 수정

## Describe your changes
- Message와 일대일 관계를 갖는 ReactionInfo 엔티티 도입  [[1]](diffhunk://#diff-7a66ebe1d87f0041fe4be4b2217064f20f773afe6678f75482fb2e82962b73b8R148-R166) [[2]](diffhunk://#diff-7a66ebe1d87f0041fe4be4b2217064f20f773afe6678f75482fb2e82962b73b8R208-R211)
[[3]](diffhunk://#diff-2cb1006d760e60ab3069d8ac14dbc5e9ed5021c6fb7e35675acd7de4655b85aaR11-R17) [[4]](diffhunk://#diff-2cb1006d760e60ab3069d8ac14dbc5e9ed5021c6fb7e35675acd7de4655b85aaR102-R108) [[5]](diffhunk://#diff-3dd7efc2c8e59a5cdccb946e838541c2b2c810abdf6ceec117b7eadb722a5a5fR1-R21)
- getMyMessages에 알맞은 Guard (IsOwnerGuard) 사용
- getMyMessages controller method에서 사용하는 Dto를 타입에 맞게 추가
  - `GetMyMessagesQuery`, `SentMessageDto`, `ReceivedMessageDto`, `GetMySentMessagesDto`, and `GetMyReceivedMessagedDto`.
- server timezone을 UTC로 고정하여 KST Host machine에서 timestamp without timezone 값을 KST로 간주하고 읽어오던 문제 개선 [[1]](diffhunk://#diff-b0e07676f16d5864921a8a5241ad841d7df9f35a37adb59b75e93ce607b7e641R1-R7) [[2]](diffhunk://#diff-bcd391d343badbf14177274557a572d397fdc2016d2c1c381e981021fe6a827aL19-R21)
  - TZ를 UTC로 설정하여 해결하였으나 추후 더 나은 방법이 있다면.. 수정 
- getMessageDetails에 message readAt 업데이트 및 message statistics 의 unread messageCount를 업데이트 하는 로직이 없었던 문제를 트랙잭션으로 추가하여 처리.


## Issue number and link
- close #25 
- close #31 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

- **신규 기능**
  - 사용자 메시지 검색을 위한 `getMyMessages` 메서드 추가.
  - 메시지 정렬 및 페이지네이션 옵션을 설정할 수 있는 새로운 DTO 클래스 추가.
  
- **버그 수정**
  - 메시지 접근 권한 검사를 개선하여 사용자 권한에 따라 메시지를 안전하게 조회할 수 있도록 수정.

- **문서화**
  - Swagger API 문서화 데코레이터를 사용하여 새로운 메서드에 대한 설명 추가.

- **테스트**
  - 사용자 메시지 검색 API에 대한 새로운 테스트 케이스 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
