### PR TITLE
✨ [Feature] 질문 숨김, 숨김해제 API

### DIFF
--- a/src/modules/questions/dto/update-question-hidden.ts
+++ b/src/modules/questions/dto/update-question-hidden.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export class ResponseUpdateQuestionHiddenDto {
+  @ApiProperty({
+    description: '숨김 및 해제 처리 완료한 질문 ID',
+    example: '1',
+  })
+  questionId: string;
+
+  @ApiProperty({
+    description: '업데이트된 질문 숨김 여부',
+    example: true,
+  })
+  isHidden: boolean;
+}
+
+export class UpdateQuestionHiddenDto {
+  @ApiProperty({
+    description: '질문 숨김 여부',
+    example: true,
+    required: true,
+  })
+  @IsBoolean()
+  isHidden: boolean;
+}

--- a/src/modules/questions/questions.controller.ts
+++ b/src/modules/questions/questions.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, HttpStatus, Param, Patch, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
 import { GenerateSwaggerApiDoc, UserAuth } from '@common/common.decorator';
@@ -6,7 +6,9 @@ import { response } from '@common/helpers/common.helper';
 import { User } from '@entities/user.entity';
 
 import { BaseResponseDto } from '@common/common.dto';
+import { CheckBigIntIdPipe } from '@common/pipes/check-bigint-id.pipe';
 import { CreateQuestionDto, ResponseCreateQuestionDto } from './dto/create-question.dto';
+import { ResponseUpdateQuestionHiddenDto, UpdateQuestionHiddenDto } from './dto/update-question-hidden';
 import { QuestionsService } from './questions.service';
 
 @ApiTags('questions')
@@ -27,5 +29,20 @@ export class QuestionsController {
   ): Promise<BaseResponseDto<ResponseCreateQuestionDto>> {
     const result = await this.questionsService.createQuestion(createQuestionDto, user.userId);
     return response(result, '질문이 성공적으로 등록되었습니다.', HttpStatus.CREATED);
+  }
+
+  @Patch(':questionId')
+  @GenerateSwaggerApiDoc({
+    summary: '질문 숨김 / 해제',
+    description: '질문을 숨기거나 숨김 해제 합니다.',
+  })
+  async updateQuestionHidden(
+    @Body() { isHidden }: UpdateQuestionHiddenDto,
+    @Param('questionId', CheckBigIntIdPipe) questionId: string,
+    @UserAuth() user: User,
+  ): Promise<BaseResponseDto<ResponseUpdateQuestionHiddenDto>> {
+    const userId = user.userId;
+    await this.questionsService.updateQuestionHidden({ questionId, isHidden, userId });
+    return response({ questionId, isHidden }, '질문이 성공적으로 숨김 혹은 숨김해제 처리되었습니다.');
   }
 }

--- a/src/modules/questions/questions.controller.ts
+++ b/src/modules/questions/questions.controller.ts
@@ -35,6 +35,7 @@ export class QuestionsController {
   @GenerateSwaggerApiDoc({
     summary: '질문 숨김 / 해제',
     description: '질문을 숨기거나 숨김 해제 합니다.',
+    responseType: ResponseUpdateQuestionHiddenDto,
   })
   async updateQuestionHidden(
     @Body() { isHidden }: UpdateQuestionHiddenDto,

--- a/src/modules/questions/questions.service.spec.ts
+++ b/src/modules/questions/questions.service.spec.ts
@@ -1,9 +1,12 @@
-import { ConflictException } from '@nestjs/common';
+import { Question } from '@entities/question.entity';
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { QuestionRepository } from '@repositories/question.repository';
+import { find } from 'lodash';
 import { QUESTION_COUNT_LIMIT } from './constants/question.constant';
 import { CreateQuestionDto } from './dto/create-question.dto';
 import { QuestionsService } from './questions.service';
+import { UpdateQuestionHiddenParam } from './types/question.types';
 
 describe('QuestionsService', () => {
   let service: QuestionsService;
@@ -18,6 +21,8 @@ describe('QuestionsService', () => {
           useValue: {
             countQuestionsByUserId: jest.fn(),
             createQuestion: jest.fn(),
+            findQuestionById: jest.fn(),
+            updateQuestionHidden: jest.fn(),
           },
         },
       ],
@@ -86,6 +91,67 @@ describe('QuestionsService', () => {
       expect(createSpy).not.toHaveBeenCalled();
     });
 
+    describe('updateQuestionHidden', () => {
+      it('질문 숨김 처리', () => {
+        expect(service.updateQuestionHidden).toBeDefined();
+      });
+
+      it('should update the hidden status of a question', async () => {
+        const param: UpdateQuestionHiddenParam = {
+          questionId: '1',
+          isHidden: true,
+          userId: '1',
+        };
+
+        const question = {
+          id: '1',
+          userId: '1',
+          content: 'test content',
+          isHidden: false,
+        } as any;
+
+        jest.spyOn(repository, 'findQuestionById').mockResolvedValue(question);
+
+        const result = await service.updateQuestionHidden(param);
+
+        expect(result).toEqual({ questionId: '1', isHidden: true });
+        expect(repository.findQuestionById).toHaveBeenCalledWith('1');
+        expect(repository.updateQuestionHidden).toHaveBeenCalledWith('1', true);
+      });
+
+      it('없는 질문이면 Not Found', async () => {
+        const param: UpdateQuestionHiddenParam = {
+          questionId: '1',
+          isHidden: true,
+          userId: '1',
+        };
+
+        jest.spyOn(repository, 'findQuestionById').mockResolvedValue(null);
+
+        await expect(service.updateQuestionHidden(param)).rejects.toThrow(NotFoundException);
+        expect(repository.findQuestionById).toHaveBeenCalledWith('1');
+      });
+
+      it('요청한 유저가 소유한 질문이 아니면 Forbidden', async () => {
+        const param: UpdateQuestionHiddenParam = {
+          questionId: '1',
+          isHidden: true,
+          userId: '2',
+        };
+
+        const question = {
+          id: '1',
+          userId: '1',
+          content: 'test content',
+          isHidden: false,
+        } as any;
+
+        jest.spyOn(repository, 'findQuestionById').mockResolvedValue(question);
+
+        await expect(service.updateQuestionHidden(param)).rejects.toThrow(ForbiddenException);
+        expect(repository.findQuestionById).toHaveBeenCalledWith('1');
+      });
+    });
     // !SECTION failure case
   });
 });

--- a/src/modules/questions/questions.service.ts
+++ b/src/modules/questions/questions.service.ts
@@ -1,8 +1,9 @@
 import { Question } from '@entities/question.entity';
-import { ConflictException, Injectable } from '@nestjs/common';
+import { ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { QuestionRepository } from '@repositories/question.repository';
 import { QUESTION_COUNT_LIMIT } from './constants/question.constant';
 import { CreateQuestionDto } from './dto/create-question.dto';
+import { UpdateQuestionHiddenParam } from './types/question.types';
 
 @Injectable()
 export class QuestionsService {
@@ -26,5 +27,20 @@ export class QuestionsService {
 
   async getQuestionById(id: string): Promise<Question | null> {
     return this.questionRepository.findQuestionById(id);
+  }
+
+  async updateQuestionHidden(param: UpdateQuestionHiddenParam) {
+    const { questionId, isHidden, userId } = param;
+    const question = await this.questionRepository.findQuestionById(questionId);
+    if (question === null) {
+      throw new NotFoundException('질문을 찾을 수 없습니다.');
+    }
+
+    if (question.userId !== userId) {
+      throw new ForbiddenException('질문의 소유자가 아닙니다.');
+    }
+
+    await this.questionRepository.updateQuestionHidden(questionId, isHidden);
+    return { questionId, isHidden };
   }
 }

--- a/src/modules/questions/types/question.types.ts
+++ b/src/modules/questions/types/question.types.ts
@@ -1,0 +1,5 @@
+export type UpdateQuestionHiddenParam = {
+  questionId: string;
+  isHidden: boolean;
+  userId: string;
+};

--- a/src/repositories/question.repository.ts
+++ b/src/repositories/question.repository.ts
@@ -38,4 +38,11 @@ export class QuestionRepository extends Repository<Question> {
       order: { createdAt: 'DESC' },
     });
   }
+
+  async updateQuestionHidden(questionId: string, isHidden: boolean): Promise<void> {
+    const result = await this.update({ questionId }, { isHidden });
+    if (result.affected === 0) {
+      throw new Error('Failed to update question hidden');
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- 질문 숨김, 해제하는 `PATCH /questions/:questionId` API 구현
## Describe your changes
- `updateQuestionHidden` controller, service, repository method 구현
- (`src/modules/questions/questions.controller.ts`) [[1]](diffhunk://#diff-b4617a9f94a61deb749d6843ff406d066161451a35995f66dbb587030554ad47L1-R11) [[2]](diffhunk://#diff-b4617a9f94a61deb749d6843ff406d066161451a35995f66dbb587030554ad47R33-R47)
-  [[1]](diffhunk://#diff-d95b57fc00a4f284a33bfd84c6a181bcf51e59e6b7c1b9212b27db42c597513cL2-R6) [[2]](diffhunk://#diff-d95b57fc00a4f284a33bfd84c6a181bcf51e59e6b7c1b9212b27db42c597513cR31-R45)
- 관련 dto, unit test, API test 추가
## Issue number and link
- close #33 
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 질문의 가시성을 업데이트하는 기능 추가.
	- 새로운 API 엔드포인트 `PATCH /questions/:questionId` 추가.

- **Bug Fixes**
	- 질문이 존재하지 않을 경우 404 오류 처리 개선.
	- 다른 사용자가 소유한 질문을 수정하려 할 때 403 오류 처리 개선.

- **Tests**
	- 질문 가시성 업데이트에 대한 테스트 케이스 추가.
	- 다양한 시나리오에 대한 테스트 커버리지 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->