### PR TITLE
🐛 [BugFix] 내가 작성한 쪽지 조회 API에서 페이지네이션 처리가 잘못되고 있던 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand",
-    "test:e2e:cache:clear": "jest --clearCache"
+    "test:debug": "TZ=UTC node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "TZ=UTC jest --config ./test/jest-e2e.json --runInBand",
+    "test:e2e:cache:clear": "TZ=UTC jest --clearCache"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.7",

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -274,7 +274,7 @@ describe('UsersService', () => {
       expect(result).toEqual(
         GetMySentMessagesDto.from(messages, {
           sentMessageCount: 2,
-          nextCursor: messages[messages.length - 1].createdAt,
+          nextCursor: null,
         }),
       );
     });
@@ -313,7 +313,7 @@ describe('UsersService', () => {
         GetMyReceivedMessagedDto.from(messages as any, {
           receivedMessageCount: 2,
           unreadMessageCount: 1,
-          nextCursor: messages[messages.length - 1].createdAt,
+          nextCursor: null,
         }),
       );
     });

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -133,7 +133,7 @@ export class UsersService {
     //});
 
     const sentMessageCount = await this.messageRepository.countBy({ senderId: userId });
-    const nextCursor = hasNextPage && messages.length > 0 ? messages[messages.length - 1].createdAt : null;
+    const nextCursor = this.getNextCursor(messages, hasNextPage);
     return { sentMessageCount, nextCursor };
   }
 
@@ -150,9 +150,12 @@ export class UsersService {
     //  select: ['receivedMessageCount', 'unreadMessageCount'],
     //  where: { userId: userId },
     //});
-    // 다음에 가져와야 하는 날짜 설정: 마지막 메시지의 생성 시간 + 1ms
-    const nextCursor =
-      hasNextPage && messages.length > 1 ? new Date(messages[messages.length - 1].createdAt.getTime() + 1) : null;
+    const nextCursor = this.getNextCursor(messages, hasNextPage);
     return { receivedMessageCount, unreadMessageCount, nextCursor };
+  }
+
+  private getNextCursor(messages: Message[], hasNextPage: boolean) {
+    // 다음에 가져와야 하는 날짜 설정: 마지막 메시지의 생성 시간 + 1ms
+    return hasNextPage && messages.length > 1 ? new Date(messages[messages.length - 1].createdAt.getTime() + 1) : null;
   }
 }


### PR DESCRIPTION
## Summary
- `GET /users/:userId/messages` API 에서 페이지네이션 처리가 제대로 되지 않던 문제 수정
- 더 이상 조회할 데이터가 없을 경우 `nextCursor` 값이 `null`이어야함
## Describe your changes
- DB는 timestamp(6)으로 6 정밀도, js Date 객체는 3의 정밀도를 가져 less than 비교가 불가능했던 문제를 +1ms 처리로 수정
- 해당 API에 대한 다양한 테스트케이스를 추가
- nextCursor 생성 함수를 따로 분리
- test 실행환경을 UTC로 설정하여 오차 해결
## Issue number and link
- close #35


@coderabbitai summary