### PR TITLE
✨ [Feature] 공유한 질문 리스트 조회 API

### DIFF
--- a/src/modules/questions/dto/base-question.dto.ts
+++ b/src/modules/questions/dto/base-question.dto.ts
@@ -18,12 +18,6 @@ export class BaseQuestionDto {
   content: string;
 
   @ApiProperty({
-    description: '숨김 여부',
-    example: false,
-  })
-  isHidden: boolean;
-
-  @ApiProperty({
     description: '생성일',
     example: '2024-11-26T00:00:00',
   })

--- a/src/modules/questions/dto/get-shared-question.dto.ts
+++ b/src/modules/questions/dto/get-shared-question.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { BaseQuestionDto } from './base-question.dto';
+
+export class SharedQuestionDto extends BaseQuestionDto {
+  @ApiProperty({
+    description: '질문 공유 및 작성한 유저 아이디',
+    example: '1',
+  })
+  userId: string;
+}
+
+export type ResponseGetSharedQuestionDto = SharedQuestionDto[];

--- a/src/modules/questions/dto/get-shared-questions.dto.ts
+++ b/src/modules/questions/dto/get-shared-questions.dto.ts
@@ -9,4 +9,4 @@ export class SharedQuestionDto extends BaseQuestionDto {
   userId: string;
 }
 
-export type ResponseGetSharedQuestionDto = SharedQuestionDto[];
+export type ResponseGetSharedQuestionsDto = SharedQuestionDto[];

--- a/src/modules/questions/dto/update-question-hidden.ts
+++ b/src/modules/questions/dto/update-question-hidden.ts
@@ -1,6 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean } from 'class-validator';
 
+export class UpdateQuestionHiddenDto {
+  @ApiProperty({
+    description: '질문 숨김 여부',
+    example: true,
+    required: true,
+  })
+  @IsBoolean()
+  isHidden: boolean;
+}
+
 export class ResponseUpdateQuestionHiddenDto {
   @ApiProperty({
     description: '숨김 및 해제 처리 완료한 질문 ID',
@@ -12,15 +22,5 @@ export class ResponseUpdateQuestionHiddenDto {
     description: '업데이트된 질문 숨김 여부',
     example: true,
   })
-  isHidden: boolean;
-}
-
-export class UpdateQuestionHiddenDto {
-  @ApiProperty({
-    description: '질문 숨김 여부',
-    example: true,
-    required: true,
-  })
-  @IsBoolean()
   isHidden: boolean;
 }

--- a/src/modules/questions/questions.controller.ts
+++ b/src/modules/questions/questions.controller.ts
@@ -8,7 +8,7 @@ import { User } from '@entities/user.entity';
 import { BaseResponseDto } from '@common/common.dto';
 import { CheckBigIntIdPipe } from '@common/pipes/check-bigint-id.pipe';
 import { CreateQuestionDto, ResponseCreateQuestionDto } from './dto/create-question.dto';
-import { SharedQuestionDto } from './dto/get-shared-question.dto';
+import { SharedQuestionDto } from './dto/get-shared-questions.dto';
 import { ResponseUpdateQuestionHiddenDto, UpdateQuestionHiddenDto } from './dto/update-question-hidden';
 import { QuestionsService } from './questions.service';
 

--- a/src/modules/questions/questions.controller.ts
+++ b/src/modules/questions/questions.controller.ts
@@ -1,13 +1,14 @@
-import { Body, Controller, HttpStatus, Param, Patch, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpStatus, Param, Patch, Post, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
-import { GenerateSwaggerApiDoc, UserAuth } from '@common/common.decorator';
+import { GenerateSwaggerApiDoc, NotUserAuth, UserAuth } from '@common/common.decorator';
 import { response } from '@common/helpers/common.helper';
 import { User } from '@entities/user.entity';
 
 import { BaseResponseDto } from '@common/common.dto';
 import { CheckBigIntIdPipe } from '@common/pipes/check-bigint-id.pipe';
 import { CreateQuestionDto, ResponseCreateQuestionDto } from './dto/create-question.dto';
+import { SharedQuestionDto } from './dto/get-shared-question.dto';
 import { ResponseUpdateQuestionHiddenDto, UpdateQuestionHiddenDto } from './dto/update-question-hidden';
 import { QuestionsService } from './questions.service';
 
@@ -29,6 +30,19 @@ export class QuestionsController {
   ): Promise<BaseResponseDto<ResponseCreateQuestionDto>> {
     const result = await this.questionsService.createQuestion(createQuestionDto, user.userId);
     return response(result, '질문이 성공적으로 등록되었습니다.', HttpStatus.CREATED);
+  }
+
+  @NotUserAuth()
+  @Get()
+  @GenerateSwaggerApiDoc({
+    summary: '공유한 질문 조회',
+    description: '사용자가 공유한 질문을 조회합니다.',
+    responseType: [SharedQuestionDto],
+    jwt: false,
+  })
+  async getSharedQuestions(@Query('userId', CheckBigIntIdPipe) sharedUserId: string) {
+    const result = await this.questionsService.getSharedQuestions(sharedUserId);
+    return response(result, '공유한 질문을 성공적으로 조회하였습니다.');
   }
 
   @Patch(':questionId')

--- a/src/modules/questions/questions.service.spec.ts
+++ b/src/modules/questions/questions.service.spec.ts
@@ -23,6 +23,7 @@ describe('QuestionsService', () => {
             createQuestion: jest.fn(),
             findQuestionById: jest.fn(),
             updateQuestionHidden: jest.fn(),
+            findSharedQuestionsByUserId: jest.fn(),
           },
         },
       ],
@@ -151,7 +152,62 @@ describe('QuestionsService', () => {
         await expect(service.updateQuestionHidden(param)).rejects.toThrow(ForbiddenException);
         expect(repository.findQuestionById).toHaveBeenCalledWith('1');
       });
+      // !SECTION failure case
     });
-    // !SECTION failure case
+
+    describe('getSharedQuestions', () => {
+      it('should be defined', () => {
+        expect(service.getSharedQuestions).toBeDefined();
+      });
+
+      it('sharedUserId가 작성한 질문을 반환', async () => {
+        const sharedUserId = '1';
+        const questions = [
+          {
+            questionId: '1',
+            userId: '1',
+            content: 'test content 1',
+            createdAt: new Date(),
+          },
+          {
+            questionId: '2',
+            userId: '1',
+            content: 'test content 2',
+            createdAt: new Date(),
+          },
+        ];
+
+        jest.spyOn(repository, 'findSharedQuestionsByUserId').mockResolvedValue(questions as any);
+
+        const result = await service.getSharedQuestions(sharedUserId);
+
+        expect(result).toEqual([
+          {
+            questionId: '1',
+            userId: '1',
+            content: 'test content 1',
+            createdAt: questions[0].createdAt,
+          },
+          {
+            questionId: '2',
+            userId: '1',
+            content: 'test content 2',
+            createdAt: questions[1].createdAt,
+          },
+        ]);
+        expect(repository.findSharedQuestionsByUserId).toHaveBeenCalledWith(sharedUserId);
+      });
+
+      it('sharedUserId가 작성한 질문이 없으면 빈 배열 반환', async () => {
+        const sharedUserId = '1';
+
+        jest.spyOn(repository, 'findSharedQuestionsByUserId').mockResolvedValue([]);
+
+        const result = await service.getSharedQuestions(sharedUserId);
+
+        expect(result).toEqual([]);
+        expect(repository.findSharedQuestionsByUserId).toHaveBeenCalledWith(sharedUserId);
+      });
+    });
   });
 });

--- a/src/modules/questions/questions.service.ts
+++ b/src/modules/questions/questions.service.ts
@@ -3,6 +3,7 @@ import { ConflictException, ForbiddenException, Injectable, NotFoundException } 
 import { QuestionRepository } from '@repositories/question.repository';
 import { QUESTION_COUNT_LIMIT } from './constants/question.constant';
 import { CreateQuestionDto } from './dto/create-question.dto';
+import { ResponseGetSharedQuestionDto, SharedQuestionDto } from './dto/get-shared-question.dto';
 import { UpdateQuestionHiddenParam } from './types/question.types';
 
 @Injectable()
@@ -23,6 +24,25 @@ export class QuestionsService {
       isHidden: isHidden,
     });
     return { questionId };
+  }
+
+  /**
+   * sharedUserId가 작성한 질문을 가져와 반환합니다.
+   *
+   * @param sharedUserId
+   * @returns
+   */
+  async getSharedQuestions(sharedUserId: string): Promise<ResponseGetSharedQuestionDto> {
+    const questions = await this.questionRepository.findSharedQuestionsByUserId(sharedUserId);
+    // select 로 필요한 필드만 가져오지만, 타입 안정성을 위하여 mapping
+    return questions.map(
+      (question: Question): SharedQuestionDto => ({
+        questionId: question.questionId,
+        userId: question.userId,
+        content: question.content,
+        createdAt: question.createdAt,
+      }),
+    );
   }
 
   async getQuestionById(id: string): Promise<Question | null> {

--- a/src/modules/questions/questions.service.ts
+++ b/src/modules/questions/questions.service.ts
@@ -3,7 +3,7 @@ import { ConflictException, ForbiddenException, Injectable, NotFoundException } 
 import { QuestionRepository } from '@repositories/question.repository';
 import { QUESTION_COUNT_LIMIT } from './constants/question.constant';
 import { CreateQuestionDto } from './dto/create-question.dto';
-import { ResponseGetSharedQuestionDto, SharedQuestionDto } from './dto/get-shared-question.dto';
+import { ResponseGetSharedQuestionsDto, SharedQuestionDto } from './dto/get-shared-questions.dto';
 import { UpdateQuestionHiddenParam } from './types/question.types';
 
 @Injectable()
@@ -32,7 +32,7 @@ export class QuestionsService {
    * @param sharedUserId
    * @returns
    */
-  async getSharedQuestions(sharedUserId: string): Promise<ResponseGetSharedQuestionDto> {
+  async getSharedQuestions(sharedUserId: string): Promise<ResponseGetSharedQuestionsDto> {
     const questions = await this.questionRepository.findSharedQuestionsByUserId(sharedUserId);
     // select 로 필요한 필드만 가져오지만, 타입 안정성을 위하여 mapping
     return questions.map(

--- a/src/modules/questions/questions.service.ts
+++ b/src/modules/questions/questions.service.ts
@@ -45,10 +45,6 @@ export class QuestionsService {
     );
   }
 
-  async getQuestionById(id: string): Promise<Question | null> {
-    return this.questionRepository.findQuestionById(id);
-  }
-
   async updateQuestionHidden(param: UpdateQuestionHiddenParam) {
     const { questionId, isHidden, userId } = param;
     const question = await this.questionRepository.findQuestionById(questionId);

--- a/src/modules/users/dto/get-my-messages.dto.ts
+++ b/src/modules/users/dto/get-my-messages.dto.ts
@@ -178,4 +178,4 @@ export class GetMyReceivedMessagedDto {
   }
 }
 
-export type GetMyMessagesResponseDto = GetMyReceivedMessagedDto | GetMySentMessagesDto;
+export type ResponseGetMyMessagesDto = GetMyReceivedMessagedDto | GetMySentMessagesDto;

--- a/src/modules/users/dto/get-my-questions.dto.ts
+++ b/src/modules/users/dto/get-my-questions.dto.ts
@@ -1,3 +1,12 @@
 import { BaseQuestionDto } from '@modules/questions/dto/base-question.dto';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MyQuestionDto extends BaseQuestionDto {
+  @ApiProperty({
+    description: '숨김 여부',
+    example: false,
+  })
+  isHidden: boolean;
+}
 
 export type ResponseGetMyQuestionsDto = BaseQuestionDto[];

--- a/src/modules/users/dto/get-my-questions.dto.ts
+++ b/src/modules/users/dto/get-my-questions.dto.ts
@@ -9,4 +9,4 @@ export class MyQuestionDto extends BaseQuestionDto {
   isHidden: boolean;
 }
 
-export type ResponseGetMyQuestionsDto = BaseQuestionDto[];
+export type ResponseGetMyQuestionsDto = MyQuestionDto[];

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -3,10 +3,10 @@ import { BaseResponseDto } from '@common/common.dto';
 import { IsOwnerGuard } from '@common/guards/is-owner.guard';
 import { response } from '@common/helpers/common.helper';
 import { CheckBigIntIdPipe } from '@common/pipes/check-bigint-id.pipe';
-import { BaseQuestionDto } from '@modules/questions/dto/base-question.dto';
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetMyMessagesQuery, GetMySentMessagesDto } from './dto/get-my-messages.dto';
+import { MyQuestionDto } from './dto/get-my-questions.dto';
 import { ResponseGetUserNicknameDto } from './dto/get-user-nickname.dto';
 import { UsersService } from './users.service';
 
@@ -19,7 +19,7 @@ export class UsersController {
   @GenerateSwaggerApiDoc({
     summary: '유저가 작성한 질문 조회',
     description: '유저 id 기준 작성한 질문 조회, 로그인한 유저 id와 일치하지 않으면 조회 불가.',
-    responseType: [BaseQuestionDto],
+    responseType: [MyQuestionDto],
   })
   @UseGuards(IsOwnerGuard)
   async getMyQuestions(@Param('userId', CheckBigIntIdPipe) userId: string) {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -16,7 +16,7 @@ import {
   GetMySentMessagesDto,
   ResponseGetMyMessagesDto,
 } from './dto/get-my-messages.dto';
-import { ResponseGetMyQuestionsDto } from './dto/get-my-questions.dto';
+import { MyQuestionDto, ResponseGetMyQuestionsDto } from './dto/get-my-questions.dto';
 import { ResponseGetUserNicknameDto } from './dto/get-user-nickname.dto';
 import { LoginType } from './users.constants';
 
@@ -58,6 +58,15 @@ export class UsersService {
    */
   async getMyQuestions(userId: string): Promise<ResponseGetMyQuestionsDto> {
     const questions = await this.questionRepository.findQuestionsByUserId(userId);
+    questions.map((question): MyQuestionDto => {
+      return {
+        questionId: question.questionId,
+        content: question.content,
+        isHidden: question.isHidden,
+        createdAt: question.createdAt,
+      };
+    });
+
     return questions;
   }
 

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -12,9 +12,9 @@ import { MessageRepository } from '@repositories/message.repository';
 import { QuestionRepository } from '@repositories/question.repository';
 import {
   GetMyMessagesQuery,
-  GetMyMessagesResponseDto,
   GetMyReceivedMessagedDto,
   GetMySentMessagesDto,
+  ResponseGetMyMessagesDto,
 } from './dto/get-my-messages.dto';
 import { ResponseGetMyQuestionsDto } from './dto/get-my-questions.dto';
 import { ResponseGetUserNicknameDto } from './dto/get-user-nickname.dto';
@@ -61,7 +61,7 @@ export class UsersService {
     return questions;
   }
 
-  async getMyMessages(userId: string, query: GetMyMessagesQuery): Promise<GetMyMessagesResponseDto> {
+  async getMyMessages(userId: string, query: GetMyMessagesQuery): Promise<ResponseGetMyMessagesDto> {
     const { type } = query;
     const paginationOptions: PaginationOption = {
       cursor: query.cursor,

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -58,16 +58,14 @@ export class UsersService {
    */
   async getMyQuestions(userId: string): Promise<ResponseGetMyQuestionsDto> {
     const questions = await this.questionRepository.findQuestionsByUserId(userId);
-    questions.map((question): MyQuestionDto => {
-      return {
+    return questions.map(
+      (question): MyQuestionDto => ({
         questionId: question.questionId,
         content: question.content,
         isHidden: question.isHidden,
         createdAt: question.createdAt,
-      };
-    });
-
-    return questions;
+      }),
+    );
   }
 
   async getMyMessages(userId: string, query: GetMyMessagesQuery): Promise<ResponseGetMyMessagesDto> {

--- a/src/repositories/question.repository.ts
+++ b/src/repositories/question.repository.ts
@@ -39,6 +39,14 @@ export class QuestionRepository extends Repository<Question> {
     });
   }
 
+  async findSharedQuestionsByUserId(sharedUserId: string): Promise<Question[]> {
+    return this.find({
+      select: ['questionId', 'userId', 'content', 'createdAt'],
+      where: { userId: sharedUserId, isHidden: false }, // 숨겨지지 않은 질문만 조회
+      order: { createdAt: 'DESC' },
+    });
+  }
+
   async updateQuestionHidden(questionId: string, isHidden: boolean): Promise<void> {
     const result = await this.update({ questionId }, { isHidden });
     if (result.affected === 0) {

--- a/test/questions.e2e-spec.ts
+++ b/test/questions.e2e-spec.ts
@@ -5,7 +5,7 @@ import * as request from 'supertest';
 import { DataSource, Repository } from 'typeorm';
 
 import { Question } from '@entities/question.entity';
-import { SharedQuestionDto } from '@modules/questions/dto/get-shared-question.dto';
+import { SharedQuestionDto } from '@modules/questions/dto/get-shared-questions.dto';
 import { UpdateQuestionHiddenDto } from '@modules/questions/dto/update-question-hidden';
 import { createTestingApp } from './helpers/create-testing-app.helper';
 


### PR DESCRIPTION
## Summary
- 공유한 질문 리스트를 조회할 수 있는 API 구현
  - `GET /questions?userId={userId}`
  - 인증 필요하지 않은 API
- unit test, API test 적용
## Describe your changes
- 공유 질문 리스트 조회에 필요한 controller, service, repository method 구현.
- 공통 property를 가지던 `BaseQuestionDto`에 `isHidden` 삭제 (해당 response에 필요없으므로 공통 dto property에서 제거)
- 타입 안정성을 위해 `Question` entity 객체를 dto 형식으로 바꾸는 매핑과정을 `getSharedQuestions`, `getMyQuestions`에 적용
  - 기존에는 "SELECT" 로 가져오는 필드값에 의존하였으나 잘못된 값을 검증할 수 없던 문제로 이와 같이 개선.
- 응답 dto 이름을 다른 dto와 동일하게 변경 (예: GetMyMessagesResponseDto → ResponseGetMyMessagesDto)

## Issue number and link
- close #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 새로운 질문 공유 기능을 추가하여 사용자가 공유한 질문을 검색할 수 있는 엔드포인트를 도입했습니다.
	- 질문 응답에 `isHidden` 속성을 포함하는 `MyQuestionDto` 클래스를 추가했습니다.
	- 공유 질문에 대한 데이터 전송 객체(`SharedQuestionDto`)를 생성했습니다.

- **Bug Fixes**
	- `getMyQuestions` 메서드의 응답 타입을 업데이트하여 더 나은 데이터 구조를 제공합니다.

- **Tests**
	- 질문 API에 대한 새로운 테스트 케이스를 추가하여 공유 질문의 검색 기능을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->