### PR TITLE
✨ [Feature] 공유한 질문 상세정보 조회 API

### DIFF
--- a/src/modules/questions/dto/get-shared-question-detail.dto.ts
+++ b/src/modules/questions/dto/get-shared-question-detail.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { BaseQuestionDto } from './base-question.dto';
+
+export class ResponseGetSharedQuestionDetailDto extends BaseQuestionDto {
+  @ApiProperty({
+    description: '질문 공유 및 작성한 유저 아이디',
+    example: '1',
+  })
+  userId: string;
+
+  @ApiProperty({
+    description: '질문 숨김 여부',
+    example: false,
+  })
+  isHidden: boolean;
+}

--- a/src/modules/questions/questions.controller.ts
+++ b/src/modules/questions/questions.controller.ts
@@ -8,6 +8,7 @@ import { User } from '@entities/user.entity';
 import { BaseResponseDto } from '@common/common.dto';
 import { CheckBigIntIdPipe } from '@common/pipes/check-bigint-id.pipe';
 import { CreateQuestionDto, ResponseCreateQuestionDto } from './dto/create-question.dto';
+import { ResponseGetSharedQuestionDetailDto } from './dto/get-shared-question-detail.dto';
 import { SharedQuestionDto } from './dto/get-shared-questions.dto';
 import { ResponseUpdateQuestionHiddenDto, UpdateQuestionHiddenDto } from './dto/update-question-hidden';
 import { QuestionsService } from './questions.service';
@@ -35,14 +36,27 @@ export class QuestionsController {
   @NotUserAuth()
   @Get()
   @GenerateSwaggerApiDoc({
-    summary: '공유한 질문 조회',
-    description: '사용자가 공유한 질문을 조회합니다.',
+    summary: '공유한 질문 조회 (인증 필요 없음)',
+    description: '사용자가 공유한 질문을 조회합니다. 질문 작성자가 숨긴 질문은 조회할 수 없습니다.',
     responseType: [SharedQuestionDto],
     jwt: false,
   })
   async getSharedQuestions(@Query('userId', CheckBigIntIdPipe) sharedUserId: string) {
     const result = await this.questionsService.getSharedQuestions(sharedUserId);
     return response(result, '공유한 질문을 성공적으로 조회하였습니다.');
+  }
+
+  @NotUserAuth()
+  @Get(':questionId')
+  @GenerateSwaggerApiDoc({
+    summary: '공유한 질문 상세 조회 (인증 필요 없음)',
+    description: '질문 상세를 조회합니다. 숨긴 질문이어도 조회 가능합니다.',
+    responseType: ResponseGetSharedQuestionDetailDto,
+    jwt: false,
+  })
+  async getSharedQuestionDetail(@Param('questionId', CheckBigIntIdPipe) questionId: string) {
+    const result = await this.questionsService.getSharedQuestionDetail(questionId);
+    return response(result, '질문 상세 조회 성공');
   }
 
   @Patch(':questionId')

--- a/src/modules/questions/questions.service.spec.ts
+++ b/src/modules/questions/questions.service.spec.ts
@@ -209,5 +209,43 @@ describe('QuestionsService', () => {
         expect(repository.findSharedQuestionsByUserId).toHaveBeenCalledWith(sharedUserId);
       });
     });
+    describe('getSharedQuestionDetail', () => {
+      it('should be defined', () => {
+        expect(service.getSharedQuestionDetail).toBeDefined();
+      });
+
+      it('질문 상세 조회', async () => {
+        const questionId = '1';
+        const question = {
+          questionId: '1',
+          userId: '1',
+          content: 'test content',
+          createdAt: new Date(),
+          isHidden: false,
+        } as any;
+
+        jest.spyOn(repository, 'findQuestionById').mockResolvedValue(question);
+
+        const result = await service.getSharedQuestionDetail(questionId);
+
+        expect(result).toEqual({
+          questionId: '1',
+          userId: '1',
+          content: 'test content',
+          createdAt: question.createdAt,
+          isHidden: false,
+        });
+        expect(repository.findQuestionById).toHaveBeenCalledWith(questionId);
+      });
+
+      it('questionId와 일치하는 질문이 없을 때 Not Found Exception', async () => {
+        const questionId = '1';
+
+        jest.spyOn(repository, 'findQuestionById').mockResolvedValue(null);
+
+        await expect(service.getSharedQuestionDetail(questionId)).rejects.toThrow(NotFoundException);
+        expect(repository.findQuestionById).toHaveBeenCalledWith(questionId);
+      });
+    });
   });
 });

--- a/src/modules/questions/questions.service.ts
+++ b/src/modules/questions/questions.service.ts
@@ -3,6 +3,7 @@ import { ConflictException, ForbiddenException, Injectable, NotFoundException } 
 import { QuestionRepository } from '@repositories/question.repository';
 import { QUESTION_COUNT_LIMIT } from './constants/question.constant';
 import { CreateQuestionDto } from './dto/create-question.dto';
+import { ResponseGetSharedQuestionDetailDto } from './dto/get-shared-question-detail.dto';
 import { ResponseGetSharedQuestionsDto, SharedQuestionDto } from './dto/get-shared-questions.dto';
 import { UpdateQuestionHiddenParam } from './types/question.types';
 
@@ -43,6 +44,21 @@ export class QuestionsService {
         createdAt: question.createdAt,
       }),
     );
+  }
+
+  async getSharedQuestionDetail(questionId: string): Promise<ResponseGetSharedQuestionDetailDto> {
+    const question = await this.questionRepository.findQuestionById(questionId);
+    if (question === null) {
+      throw new NotFoundException('질문을 찾을 수 없습니다.');
+    }
+
+    return {
+      questionId: question.questionId,
+      userId: question.userId,
+      content: question.content,
+      createdAt: question.createdAt,
+      isHidden: question.isHidden,
+    };
   }
 
   async updateQuestionHidden(param: UpdateQuestionHiddenParam) {

--- a/test/questions.e2e-spec.ts
+++ b/test/questions.e2e-spec.ts
@@ -228,6 +228,37 @@ describe('Questions API test', () => {
         });
     });
 
+    it('숨김 처리된 질문이어도 값을 반환해야 한다.', async () => {
+      const question = await questionRepository.save({
+        content: '숨겨진 테스트 질문',
+        isHidden: true,
+        userId: testUserId,
+      });
+      createdQuestionIds.push(question.questionId);
+
+      return request(app.getHttpServer())
+        .get(`/questions/${question.questionId}`)
+        .expect(200)
+        .expect((response) => {
+          expect(response.body).toHaveProperty('data');
+          expect(response.body).toHaveProperty('message');
+          expect(response.body).toHaveProperty('status');
+
+          expect(response.body.status).toBe(200);
+
+          const data: ResponseGetSharedQuestionDetailDto = response.body.data;
+          expect(data).toHaveProperty('userId');
+          expect(data).toHaveProperty('questionId');
+          expect(data).toHaveProperty('content');
+          expect(data).toHaveProperty('createdAt');
+          expect(data).toHaveProperty('isHidden');
+
+          expect(data.userId).toBe(testUserId);
+          expect(data.content).toBe('숨겨진 테스트 질문');
+          expect(data.isHidden).toBe(true);
+        });
+    });
+
     it('없는 questionId일 경우 404', async () => {
       return request(app.getHttpServer())
         .get('/questions/99999999999999999')


### PR DESCRIPTION
## Summary
- 질문을 특정하여 공유하였을 때의 상세정보를 조회하는 공유한 질문 상세정보 조회 API 구현
  - `GET /question/:questionId`
## Describe your changes
- `getSharedQuestionDetail`controller, service method 구현
  - unit, API test 구현
## Issue number and link
- close #38 


---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 공유 질문에 대한 세부 정보를 조회할 수 있는 기능 추가.
  - 인증 없이 숨겨진 질문을 포함한 특정 질문의 세부 정보를 가져오는 API 엔드포인트 추가.

- **버그 수정**
  - 기존 메서드의 인증 및 질문 가시성 관련 동작 명확화.

- **테스트**
  - 새로운 API 엔드포인트에 대한 테스트 케이스 추가, 성공적인 조회 및 오류 처리 검증.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->