### PR TITLE
✨ [Feature] 쪽지 상태 변경 API

### DIFF
--- a/src/common/common.decorator.ts
+++ b/src/common/common.decorator.ts
@@ -37,7 +37,7 @@ export const ResponseDtoType = <T extends Type<unknown> | [Type<unknown>]>(t: T,
     ApiExtraModels(BaseResponseDto, ...types), // BaseResponseDto와 모든 타입을 추가
     responseMap[status]({
       schema: {
-        title: `ResponseDtoTypeOf${types.map((type) => type.name).join('And')}`,
+        title: types.map((type) => type.name).join('And'),
         allOf: [
           { $ref: getSchemaPath(BaseResponseDto) },
           {

--- a/src/modules/messages/constants/messages.constant.ts
+++ b/src/modules/messages/constants/messages.constant.ts
@@ -1,2 +1,3 @@
 export const MESSAGE_CONTENT_MAX = 200;
 export const MESSAGE_CONTENT_MIN = 2;
+export const MESSAGE_STATUS = ['normal', 'hidden', 'reported'] as const;

--- a/src/modules/messages/dto/create-message.dto.ts
+++ b/src/modules/messages/dto/create-message.dto.ts
@@ -1,5 +1,5 @@
 import { IsBigIntIdString } from '@common/decorators/is-bigint-id-string.decorator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, OmitType } from '@nestjs/swagger';
 import { IsIn, IsOptional, IsString, Length } from 'class-validator';
 import { MESSAGE_CONTENT_MAX, MESSAGE_CONTENT_MIN } from '../constants/messages.constant';
 
@@ -40,6 +40,10 @@ export class CreateMessageDto {
   //@IsBigIntIdString() - 감정id가 고정된 값이므로 사용하지 않음. 추후 변경될 수 있음
   emotionId?: string;
 }
+
+export class CreateEmotionMessageDto extends OmitType(CreateMessageDto, ['questionId']) {}
+
+export class CreateQuestionMessageDto extends OmitType(CreateMessageDto, ['emotionId']) {}
 
 export class ResponseCreateMessageDto {
   @ApiProperty({

--- a/src/modules/messages/dto/message-detail.dto.ts
+++ b/src/modules/messages/dto/message-detail.dto.ts
@@ -1,6 +1,6 @@
 import { Message } from '@entities/message.entity';
 import { ApiProperty } from '@nestjs/swagger';
-import { getMessageStatusString, getReactionTypeKorean } from '../helpers/message-reaction.helper';
+import { getReactionTypeKorean, toMessageStatusString } from '../helpers/message-reaction.helper';
 import { MessageStatusString, MessageType } from '../types/messages.type';
 import { BaseMessageDto } from './base-message.dto';
 
@@ -82,7 +82,7 @@ export class ReceivedMessageDetailDto extends MessageDetailDto {
 
   static from(message: Message): ReceivedMessageDetailDto {
     const base = MessageDetailDto.baseFrom(message);
-    const status = getMessageStatusString(message.status);
+    const status = toMessageStatusString(message.status);
     return {
       ...base,
       type: 'received',

--- a/src/modules/messages/dto/update-message-status.dto.ts
+++ b/src/modules/messages/dto/update-message-status.dto.ts
@@ -10,7 +10,7 @@ export class UpdateMessageStatusDto {
     enum: MESSAGE_STATUS,
     required: true,
   })
-  @IsEnum(MESSAGE_STATUS, { message: 'status은 hidden, normal, reported 중 하나여야 합니다.' })
+  @IsEnum(MESSAGE_STATUS, { message: 'status는 hidden, normal, reported 중 하나여야 합니다.' })
   status: MessageStatusString;
 }
 

--- a/src/modules/messages/dto/update-message-status.dto.ts
+++ b/src/modules/messages/dto/update-message-status.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { MESSAGE_STATUS } from '../constants/messages.constant';
+import { MessageStatusString } from '../types/messages.type';
+
+export class UpdateMessageStatusDto {
+  @ApiProperty({
+    description: '쪽지 상태',
+    example: 'hidden',
+    enum: MESSAGE_STATUS,
+    required: true,
+  })
+  @IsEnum(MESSAGE_STATUS, { message: 'status은 hidden, normal, reported 중 하나여야 합니다.' })
+  status: MessageStatusString;
+}
+
+export class ResponseUpdateMessageStatusDto {
+  @ApiProperty({ description: '쪽지 id', example: '1' })
+  messageId: string;
+
+  @ApiProperty({ description: '반영된 상태값', example: 'hidden' })
+  status: MessageStatusString;
+}

--- a/src/modules/messages/helpers/message-reaction.helper.ts
+++ b/src/modules/messages/helpers/message-reaction.helper.ts
@@ -3,17 +3,24 @@ import { MessageStatus } from '@entities/message.entity';
 import { ReactionTemplateType } from '@entities/reaction-template.entity';
 import { MessageStatusString, ReactionTypeKorean } from '../types/messages.type';
 
-export function getMessageStatusString(status: MessageStatus): MessageStatusString {
-  switch (status) {
-    case MessageStatus.NORMAL:
-      return 'normal';
-    case MessageStatus.HIDDEN:
-      return 'hidden';
-    case MessageStatus.REPORTED:
-      return 'reported';
-    default:
-      throw new Error(`Invalid message status: ${status}`);
-  }
+const MESSAGE_STATUS_MAPPING = {
+  normal: MessageStatus.NORMAL,
+  hidden: MessageStatus.HIDDEN,
+  reported: MessageStatus.REPORTED,
+} as const;
+
+const REVERSE_STATUS_MAPPING = {
+  [MessageStatus.NORMAL]: 'normal',
+  [MessageStatus.HIDDEN]: 'hidden',
+  [MessageStatus.REPORTED]: 'reported',
+} as const;
+
+export function toMessageStatusEnum(status: MessageStatusString): MessageStatus {
+  return MESSAGE_STATUS_MAPPING[status];
+}
+
+export function toMessageStatusString(status: MessageStatus): MessageStatusString {
+  return REVERSE_STATUS_MAPPING[status];
 }
 
 export function getReactionTypeKorean(type: ReactionTemplateType): ReactionTypeKorean {

--- a/src/modules/messages/helpers/message-reaction.helper.ts
+++ b/src/modules/messages/helpers/message-reaction.helper.ts
@@ -3,12 +3,20 @@ import { MessageStatus } from '@entities/message.entity';
 import { ReactionTemplateType } from '@entities/reaction-template.entity';
 import { MessageStatusString, ReactionTypeKorean } from '../types/messages.type';
 
+/**
+ * 문자열 상태값을 MessageStatus enum으로 변환하기 위한 매핑
+ * @example MESSAGE_STATUS_MAPPING['normal'] === MessageStatus.NORMAL
+ */
 const MESSAGE_STATUS_MAPPING = {
   normal: MessageStatus.NORMAL,
   hidden: MessageStatus.HIDDEN,
   reported: MessageStatus.REPORTED,
 } as const;
 
+/**
+ * MessageStatus enum을 문자열 상태값으로 변환하기 위한 매핑
+ * @example REVERSE_STATUS_MAPPING[MessageStatus.NORMAL] === 'normal'
+ */
 const REVERSE_STATUS_MAPPING = {
   [MessageStatus.NORMAL]: 'normal',
   [MessageStatus.HIDDEN]: 'hidden',

--- a/src/modules/messages/messages.controller.ts
+++ b/src/modules/messages/messages.controller.ts
@@ -2,10 +2,16 @@ import { GenerateSwaggerApiDoc, UserAuth } from '@common/common.decorator';
 import { response } from '@common/helpers/common.helper';
 import { CheckBigIntIdPipe } from '@common/pipes/check-bigint-id.pipe';
 import { User } from '@entities/user.entity';
-import { Body, Controller, Get, HttpStatus, Param, Post } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-import { CreateMessageDto, ResponseCreateMessageDto } from './dto/create-message.dto';
+import { Body, Controller, Get, HttpStatus, Param, Patch, Post } from '@nestjs/common';
+import { /*ApiBody, ApiExtraModels, , getSchemaPath*/ ApiTags } from '@nestjs/swagger';
+import {
+  //CreateEmotionMessageDto,
+  CreateMessageDto,
+  //CreateQuestionMessageDto,
+  ResponseCreateMessageDto,
+} from './dto/create-message.dto';
 import { ReceivedMessageDetailDto } from './dto/message-detail.dto';
+import { ResponseUpdateMessageStatusDto, UpdateMessageStatusDto } from './dto/update-message-status.dto';
 import { MessagesService } from './messages.service';
 
 @ApiTags('messages')
@@ -19,6 +25,20 @@ export class MessagesController {
     responseType: ResponseCreateMessageDto,
     responseStatus: HttpStatus.CREATED,
   })
+  //@ApiExtraModels(CreateEmotionMessageDto, CreateQuestionMessageDto)
+  //@ApiBody({
+  //  schema: {
+  //    title: 'CreateMessageDto',
+  //    oneOf: [{ $ref: getSchemaPath(CreateEmotionMessageDto) }, { $ref: getSchemaPath(CreateQuestionMessageDto) }],
+  //    discriminator: {
+  //      propertyName: 'emotionId', // emotionId의 존재여부로 구분
+  //      mapping: {
+  //        emotion: getSchemaPath(CreateEmotionMessageDto),
+  //        question: getSchemaPath(CreateQuestionMessageDto),
+  //      },
+  //    },
+  //  },
+  //})
   @Post()
   async createMessage(@Body() createMessageDto: CreateMessageDto, @UserAuth() user: User) {
     return response(
@@ -38,5 +58,20 @@ export class MessagesController {
     const { userId } = user;
     const result = await this.messagesService.getMessageDetail({ messageId, userId });
     return response(result, '쪽지 상세정보가 조회되었습니다.');
+  }
+
+  @GenerateSwaggerApiDoc({
+    summary: '쪽지 상태 변경',
+    description: '쪽지의 상태를 변경합니다.',
+    responseType: ResponseUpdateMessageStatusDto,
+  })
+  @Patch(':messageId')
+  async updateMessageStatus(
+    @Param('messageId', CheckBigIntIdPipe) messageId: string,
+    @Body() { status }: UpdateMessageStatusDto,
+    @UserAuth() user: User,
+  ) {
+    const result = await this.messagesService.updateMessageStatus({ messageId, userId: user.userId, status });
+    return response(result, '쪽지 상태가 변경되었습니다');
   }
 }

--- a/src/modules/messages/messages.controller.ts
+++ b/src/modules/messages/messages.controller.ts
@@ -72,6 +72,6 @@ export class MessagesController {
     @UserAuth() user: User,
   ) {
     const result = await this.messagesService.updateMessageStatus({ messageId, userId: user.userId, status });
-    return response(result, '쪽지 상태가 변경되었습니다');
+    return response(result, `쪽지 상태가 ${status}로 변경되었습니다`);
   }
 }

--- a/src/modules/messages/messages.service.ts
+++ b/src/modules/messages/messages.service.ts
@@ -84,6 +84,12 @@ export class MessagesService {
     return ReceivedMessageDetailDto.from(message);
   }
 
+  /**
+   * 쪽지 상태를 변경합니다. 받은 쪽지인 경우만 가능.
+   *
+   * @param param messageId, userId, status를 포함하는 parameter
+   * @returns 변경된 쪽지 id와 status
+   */
   async updateMessageStatus(param: UpdateMessageStatusParam) {
     const { userId, messageId } = param;
     const status = toMessageStatusEnum(param.status);
@@ -126,7 +132,7 @@ export class MessagesService {
    * question 에 속하지 않는 자유 쪽지를 생성합니다.
    * emotion 1 : 응원과 감사, 2: 솔직한 대화.
    *
-   * @param messageData \
+   * @param messageData { senderId, receiverId, content }
    * @param emotionId
    * @returns
    */

--- a/src/modules/messages/messages.service.ts
+++ b/src/modules/messages/messages.service.ts
@@ -1,8 +1,15 @@
-import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { EmotionRepository, MessageRepository, QuestionRepository, UserRepository } from '@repositories/index';
 import { CreateMessageDto, ResponseCreateMessageDto } from './dto/create-message.dto';
 import { ReceivedMessageDetailDto, SentMessageDetailDto } from './dto/message-detail.dto';
-import { MessageBaseData, MessageDetailParam } from './types/messages.type';
+import { toMessageStatusEnum } from './helpers/message-reaction.helper';
+import { MessageBaseData, MessageDetailParam, UpdateMessageStatusParam } from './types/messages.type';
 
 @Injectable()
 export class MessagesService {
@@ -75,6 +82,25 @@ export class MessagesService {
       return SentMessageDetailDto.from(message);
     }
     return ReceivedMessageDetailDto.from(message);
+  }
+
+  async updateMessageStatus(param: UpdateMessageStatusParam) {
+    const { userId, messageId } = param;
+    const status = toMessageStatusEnum(param.status);
+
+    const message = await this.messageRepository.findOne({ where: { messageId: messageId } });
+    if (message === null) {
+      throw new NotFoundException('쪽지가 존재하지 않습니다.');
+    }
+    if (message.receiverId !== userId) {
+      throw new ForbiddenException('쪽지를 수정할 권한이 없습니다.');
+    }
+
+    const result = await this.messageRepository.update({ messageId }, { status: status });
+    if (result.affected === 0) {
+      throw new InternalServerErrorException('쪽지 상태 변경 실패');
+    }
+    return { messageId, status: param.status };
   }
 
   /**

--- a/src/modules/messages/types/messages.type.ts
+++ b/src/modules/messages/types/messages.type.ts
@@ -1,3 +1,5 @@
+import { MESSAGE_STATUS } from '../constants/messages.constant';
+
 export type MessageBaseData = {
   senderId: string;
   receiverId: string;
@@ -20,11 +22,17 @@ export type MessageType = 'received' | 'sent';
 
 export type MessageOrder = 'desc' | 'asc';
 
-export type MessageStatusString = 'normal' | 'hidden' | 'reported';
+export type MessageStatusString = (typeof MESSAGE_STATUS)[number];
 
 export type ReactionTypeKorean = '감사' | '사과' | '응원' | '화해';
 
 export type MessageDetailParam = {
   messageId: string;
   userId: string;
+};
+
+export type UpdateMessageStatusParam = {
+  messageId: string;
+  userId: string;
+  status: MessageStatusString;
 };

--- a/src/modules/users/dto/get-my-messages.dto.ts
+++ b/src/modules/users/dto/get-my-messages.dto.ts
@@ -1,5 +1,5 @@
 import { Message } from '@entities/message.entity';
-import { getMessageStatusString } from '@modules/messages/helpers/message-reaction.helper';
+import { toMessageStatusString } from '@modules/messages/helpers/message-reaction.helper';
 import { MessageOrder, MessageStatusString, MessageType } from '@modules/messages/types/messages.type';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
@@ -16,6 +16,7 @@ export class GetMyMessagesQuery {
   @ApiProperty({
     description: '받은 쪽지, 보낸 쪽지 구분 (received/sent)',
     example: 'received',
+    enum: ['received', 'sent'],
   })
   @IsIn(['received', 'sent'])
   type: MessageType; // received/sent
@@ -45,6 +46,8 @@ export class GetMyMessagesQuery {
     description: '정렬 (desc/asc), (default: desc)',
     required: false,
     example: 'desc',
+    default: 'desc',
+    enum: ['desc', 'asc'],
   })
   @IsOptional()
   @IsIn(['desc', 'asc'])
@@ -75,7 +78,7 @@ export class ReceivedMessageDto extends BaseMessageDto {
       receiverNickname: message.receiver.nickname,
       content: message.content,
       createdAt: message.createdAt,
-      status: getMessageStatusString(message.status),
+      status: toMessageStatusString(message.status),
       readAt: message.readAt,
     };
   }


### PR DESCRIPTION
## Summary
- 쪽지 상태를 변경하는 API 구현
  - `PATCH /messages/:messageId`
## Describe your changes
- `updateMessageStatus` method 구현
- getMessageStatusString 함수를 toMessageStatusString과 toMessageStatusEnum으로 분리하여 status 처리 개선
  - db에서는 smallint, api에서는 string으로 통신
## Issue number and link
- close #42 
--- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 메시지 상태 업데이트를 위한 새로운 HTTP PATCH 엔드포인트 추가.
	- 새로운 메시지 상태 상수 `MESSAGE_STATUS` 추가.
	- `CreateEmotionMessageDto` 및 `CreateQuestionMessageDto` 클래스 추가.
	- 메시지 상태 업데이트를 위한 DTO 클래스 `UpdateMessageStatusDto` 및 응답 DTO `ResponseUpdateMessageStatusDto` 추가.

- **Bug Fixes**
	- 메시지 상태 문자열 변환 로직 수정.

- **Tests**
	- 메시지 상태 업데이트 기능에 대한 새로운 테스트 케이스 추가.
	- 기존 테스트에서 변수 이름 변경 및 업데이트.

- **Documentation**
	- API 문서화 개선을 위한 메타데이터 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->